### PR TITLE
Fix CDDL definitions

### DIFF
--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -271,12 +271,7 @@ suite = int
 
 version = int
 
-data_items = (
-   attestation: 1,
-   trusted_apps: 2, 
-   extensions: 3,
-   suit_commands: 4
-)
+data_items = int
 
 QueryRequest = (
      TYPE : int, 

--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -322,7 +322,7 @@ th the TAM and the TEEP Agent. A TAM can query the TEEP Agent for the support of
 </section> 
 
 <section title="QueryResponse">
-<t
+<t>
  <figure>
  <artwork><![CDATA[           
 ext_info = int

--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -271,12 +271,12 @@ suite = int
 
 version = int
 
-data_items = int
+data_item = int
 
 QueryRequest = (
      TYPE : int, 
      TOKEN : bstr,
-     REQUEST : [+data_items],
+     REQUEST : [+data_item],
      ? CIPHER_SUITE : [+suite],
      ? NONCE : bstr,
      ? VERSION : [+version],

--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -273,7 +273,7 @@ version = int
 
 data_item = int
 
-QueryRequest = (
+QueryRequest = {
      TYPE : int, 
      TOKEN : bstr,
      REQUEST : [+data_item],
@@ -282,7 +282,7 @@ QueryRequest = (
      ? VERSION : [+version],
      ? OCSP_DATA : bstr, 
      * $$extensions
-)
+}
                        ]]></artwork>
           </figure>
           </t> 
@@ -322,7 +322,7 @@ th the TAM and the TEEP Agent. A TAM can query the TEEP Agent for the support of
  <artwork><![CDATA[           
 ext_info = int
 
-QueryResponse = (
+QueryResponse = {
      TYPE : int, 
      TOKEN : bstr,
      ? SELECTED_CIPHER_SUITE : suite,
@@ -331,7 +331,7 @@ QueryResponse = (
      ? TA_LIST  : [+bstr],
      ? EXT_LIST : [+ext_info],
      * $$extensions
-)
+}
                        ]]></artwork>
           </figure>
 </t>
@@ -361,12 +361,12 @@ QueryResponse = (
 <t>
  <figure>
  <artwork><![CDATA[   
-TrustedAppInstall = (
+TrustedAppInstall = {
      TYPE : int, 
      TOKEN : bstr,
      ? MANIFEST_LIST  : [+ SUIT_Outer_Wrapper],
      * $$extensions
-)
+}
                        ]]></artwork>
           </figure>
           </t>
@@ -394,12 +394,12 @@ is used for initial TA installation but also for TA updates. </t>
 <t>
  <figure>
  <artwork><![CDATA[ 
-TrustedAppDelete  = (
+TrustedAppDelete  = {
      TYPE : int, 
      TOKEN : bstr,
      ? TA_LIST  : [+bstr],
      * $$extensions
-)
+}
                        ]]></artwork>
           </figure>
           </t>
@@ -424,12 +424,12 @@ message is returned by the TEEP Agent. In case of an error, an Error message is 
 <t>
  <figure>
  <artwork><![CDATA[ 
-Success = (
+Success = {
      TYPE : int,
      TOKEN : bstr,
      ? MSG : tstr,
      * $$extensions
-)
+}
                        ]]></artwork>
           </figure>
           </t>
@@ -454,7 +454,7 @@ Success = (
 <t>
  <figure>
  <artwork><![CDATA[ 
-Error = (
+Error = {
      TYPE : int,
      TOKEN : bstr,
      ERR_CODE : int,
@@ -462,7 +462,7 @@ Error = (
      ? CIPHER_SUITE : [+suite],
      ? VERSION : [+version],
      * $$extensions
-)
+}
                        ]]></artwork>
           </figure>
           </t>


### PR DESCRIPTION
# IMPORTANT: 2020-02-20

**Merging this PR automatically merges #8**. The only reason I separated #8 is because this is a different issue.

# Issue / Proposal Description

I examined CDDL definitions of the TEEP protocol and found some errors (I think).

My fix is checked on the CDDL tool mentioned in RFC 8610 (CDDL) as “A rough CDDL tool”.

If I got it wrong, sorry and let me know.


`data_items`
-------------

`data_items` type (used in `QueryRequest`) is intended to be an integer type which indicates what information the TAM requests from the TEEP Agent. It is like `enum` in C-based languages.

However, the original CDDL definition declares that, `data_items` is a group of sequence 1, 2, 3 and 4. As a consequence, `REQUEST` field conforms to the CDDL definition only when it consists of repetition of 1, 2, 3 and 4 (e.g. `[1,2,3,4]`, `[1,2,3,4,1,2,3,4]` and so on). I guess this is not what you want.

My commit makes this type just an alias of `int` (just like `suite` and `version` used in `QueryRequest`) because what value means is documented below the CDDL counterpart.

I also made type name singular (`data_item`) to make sure that a value of this type corresponds *one of* IANA registered information elements.


`ta_id` “type” (Updated on 2020-02-20)
-----------------

This change is cancelled because this “type” is removed in latest `master`.


Various TEEP message “types”
-------------------------------

* `QueryRequest`
* `QueryResponse`
* `TrustedAppInstall`
* `TrustedAppDelete`
* `Error`
* `Success`

They must be real types. In the `Outer_Wrapper` definition, we can find this:

```
    teep-message                => (QueryRequest / 
                                    QueryResponse / 
                                    TrustedAppInstall / 
                                    TrustedAppDelete / 
                                    Error / 
                                    Success ),
```

`A => B` operator requires `B` to be a type. Because `B` here corresponds to a choice of six “types” above, all six “types” *must* be real types (not groups).

Considering multiple optional fields and possible extensions, I thought they should be “map” types.