### PR TITLE
Possible fix (and change) for contributor names

### DIFF
--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -757,7 +757,7 @@ Value | Ciphersuite
       </t>
       <t>We would like to thank Eve Schooler for the suggestion of the protocol name.</t>
 
-      <t>We would like to thank Akira Tsukamoto, Isobe Kohei, Kohei Isobe, Tsukasa Ooi, and Yuichi Takita for their valuable implementation feedback. </t>
+      <t>We would like to thank Akira Tsukamoto, Kohei Isobe, Tsukasa Ooi, and Yuichi Takita for their valuable implementation feedback. </t>
 
     </section> <!-- Acknowledgements --> 
 

--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -757,7 +757,7 @@ Value | Ciphersuite
       </t>
       <t>We would like to thank Eve Schooler for the suggestion of the protocol name.</t>
 
-      <t>We would like to thank Akira Tsukamoto, Kohei Isobe, Kuniyasu Suzaki, Tsukasa Oi, and Yuichi Takita for their valuable implementation feedback. </t>
+      <t>We would like to thank Akira Tsukamoto (AIST), Kohei Isobe (TRASIO/SECOM), Kuniyasu Suzaki (TRASIO/AIST), Tsukasa Oi (TRASIO), and Yuichi Takita (SECOM) for their valuable implementation feedback. </t>
 
     </section> <!-- Acknowledgements --> 
 

--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -757,7 +757,7 @@ Value | Ciphersuite
       </t>
       <t>We would like to thank Eve Schooler for the suggestion of the protocol name.</t>
 
-      <t>We would like to thank Akira Tsukamoto, Kohei Isobe, Tsukasa Ooi, and Yuichi Takita for their valuable implementation feedback. </t>
+      <t>We would like to thank Akira Tsukamoto, Kohei Isobe, Tsukasa Oi, and Yuichi Takita for their valuable implementation feedback. </t>
 
     </section> <!-- Acknowledgements --> 
 

--- a/draft-ietf-teep-protocol.xml
+++ b/draft-ietf-teep-protocol.xml
@@ -757,7 +757,7 @@ Value | Ciphersuite
       </t>
       <t>We would like to thank Eve Schooler for the suggestion of the protocol name.</t>
 
-      <t>We would like to thank Akira Tsukamoto, Kohei Isobe, Tsukasa Oi, and Yuichi Takita for their valuable implementation feedback. </t>
+      <t>We would like to thank Akira Tsukamoto, Kohei Isobe, Kuniyasu Suzaki, Tsukasa Oi, and Yuichi Takita for their valuable implementation feedback. </t>
 
     </section> <!-- Acknowledgements --> 
 


### PR DESCRIPTION
I know, this is not relevant to the TEEP protocol itself. But it changes contributor names.

1.  “Isobe Kohei” and “Kohei Isobe” seems to be the same person (_missing_ contributor?)  
    I propose to keep the name represented by western “given name, family name” order (“Kohei Isobe”) and remove the another (“Isobe Kohei”).  I recommend to check whether “missing” contributor exists.  
    **Edit:** It's likely that Mr. Kuniyasu Suzaki from TRASIO/AIST is the _missing_ contributor considering SIoT and IETF 106 hackathon participants.
2.  “Tsukasa Oi” (who made this proposal) prefers this passport name  
    I used "Ooi" until early 2011 because it's more faithful to original Japanese representation (three mora "o-o-i", two syllables "oo-i") but this romanization did not match to my passport which caused some problems.  Since mid 2011, I prefer "Oi" (or capitalized "OI"), my passport name.
3.  Contributors' affiliation?
    I received an internal request to credit contributors' affiliation (company/organization names). While the last commit is optional, it adds contributors' affiliation based on their official position.