### PR TITLE
option -3 is not supported at kdrfc in Ubuntu.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IETF_DRAFT = $(patsubst %.md,%, $(IETF_DRAFT_MD))
 
 $(IETF_DRAFT).txt: $(IETF_DRAFT).md
 	echo $(IETF_DRAFT)
-	kdrfc -3 $<
+	kdrfc $<
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The kdrfc in Ubuntu had build error with the option.
Works fine converting the markdown file to txt without the -3 option