### PR TITLE
Fix how to install ruby-kramdown-rfc2629

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ TEEP Protocol Draft
 ### Prerequisite packages
 
 ```
-sudo apt install xml2rfc ruby-kramdown-rfc2629
+sudo apt install xml2rfc
+sudo gem install kramdown-rfc2629
 ```
 
-### Converting
+### Generating draft from markdown file
 
 ```
 make

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -55,6 +55,15 @@ author:
   code: ''
   country: US
   email: dthaler@microsoft.com
+- ins: A. Tsukamoto
+  name: Akira Tsukamoto
+  org: AIST
+  street: ''
+  city: ''
+  region: ''
+  code: ''
+  country: US
+  email: akira.tsukamoto@aist.go.jp
 normative:
   RFC4648: 
   RFC8152: 


### PR DESCRIPTION
The ruby-kramdown-rfc2629 from apt repository is old and do not have the
`kdrfc -3` option.