### PR TITLE
Fix CDDL message type numbers to match sections 4.6 and 4.7

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -996,8 +996,8 @@ TEEP-TYPE-query-request = 1
 TEEP-TYPE-query-response = 2
 TEEP-TYPE-trusted-app-install = 3
 TEEP-TYPE-trusted-app-delete = 4
-TEEP-TYPE-teep-error = 5
-TEEP-TYPE-teep-success = 6
+TEEP-TYPE-teep-success = 5
+TEEP-TYPE-teep-error = 6
 
 version = uint .size 4
 ext-info = uint 


### PR DESCRIPTION
Sections 4.6 and 4.7 say success is 5 and error is 6.
The CDDL has them backwards and says error is 5 and success is 6.
Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>