### PR TITLE
The cipher-suites was undefined, use only supported-cipher-suites

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -363,8 +363,8 @@ request
   
    Further values may be added in the future via IANA registration.
 
-cipher-suites
-: The cipher-suites parameter lists the ciphersuite(s) supported by the TAM. Details
+supported-cipher-suites
+: The supported-cipher-suites parameter lists the ciphersuite(s) supported by the TAM. Details
   about the ciphersuite encoding can be found in {{ciphersuite}}.
 
 nonce
@@ -583,7 +583,7 @@ teep-error = [
   err-code: uint,
   options: {
      ? err-msg => text,
-     ? cipher-suites => [ + suite ],
+     ? supported-cipher-suites => [ + suite ],
      ? versions => [ + version ],
      * $$teep-error--extensions,
      * $$teep-option-extensions
@@ -609,8 +609,8 @@ err-msg
 : The err-msg parameter is a human-readable diagnostic text that MUST be encoded
   using UTF-8 {{RFC3629}} using Net-Unicode form {{RFC5198}}.
 
-cipher-suites
-: The cipher-suites parameter lists the ciphersuite(s) supported by the TEEP Agent.
+supported-cipher-suites
+: The supported-cipher-suites parameter lists the ciphersuite(s) supported by the TEEP Agent.
   This field is optional but MUST be returned with the ERR_UNSUPPORTED_CRYPTO_ALG
   error message.
 
@@ -712,19 +712,19 @@ as a map key.
 
 This specification uses the following mapping:
 
-| Name                  | Label |
-| cipher-suites         |     1 |
-| nonce                 |     2 |
-| version               |     3 |
-| ocsp-data             |     4 |
-| selected-cipher-suite |     5 |
-| selected-version      |     6 |
-| eat                   |     7 |
-| ta-list               |     8 |
-| ext-list              |     9 |
-| manifest-list         |    10 |
-| msg                   |    11 |
-| err-msg               |    12 |
+| Name                    | Label |
+| supported-cipher-suites |     1 |
+| nonce                   |     2 |
+| version                 |     3 |
+| ocsp-data               |     4 |
+| selected-cipher-suite   |     5 |
+| selected-version        |     6 |
+| eat                     |     7 |
+| ta-list                 |     8 |
+| ext-list                |     9 |
+| manifest-list           |    10 |
+| msg                     |    11 |
+| err-msg                 |    12 |
 
 
 # Ciphersuites {#ciphersuite}
@@ -1092,7 +1092,7 @@ teep-error = [
   token: uint,
   options: {
      ? err-msg => text,
-     ? cipher-suites => [ + suite ],
+     ? supported-cipher-suites => [ + suite ],
      ? versions => [ + version ],
      * $$teep-error--extensions,
      * $$teep-option-extensions
@@ -1100,7 +1100,7 @@ teep-error = [
   err-code: uint,
 ]
 
-cipher-suites = 1
+supported-cipher-suites = 1
 nonce = 2
 versions = 3
 ocsp-data = 4


### PR DESCRIPTION
This is for https://github.com/ietf-teep/teep-protocol/issues/54.
Revised to use only supported-cipher-suites.

Both supported-cipher-suites and cipher-suites were used in the draft but only cipher-suites had a map key.
Without the map key, it is not able to create the cbor binary.
Considering the usage of the cipher-suites, replacing the cipher-suites with supported-cipher-suites looks fine.
