### PR TITLE
Fix errors when generating xml txt from md

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -88,6 +88,7 @@ informative:
   RFC8610: 
   RFC8126: 
   RFC8915: 
+  RFC4122: 
 
 --- abstract
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -786,7 +786,7 @@ A ciphersuite consists of an AEAD algorithm, an HMAC algorithm, and a signature
 algorithm.
 Each ciphersuite is identified with an integer value, which corresponds to
 an IANA registered
-ciphersuite (see {{ciphersuit-registry}}. This document specifies two ciphersuites.
+ciphersuite (see {{ciphersuite-registry}}. This document specifies two ciphersuites.
 
 | Value | Ciphersuite                                    |
 |     1 | AES-CCM-16-64-128, HMAC 256/256, X25519, EdDSA |


### PR DESCRIPTION
These changes are for fixing errors when generating xml and txt files from md.

Fixes following error messages:
```
xml2rfc draft-ietf-teep-protocol-latest.xml
Error: Unable to validate the XML document: draft-ietf-teep-protocol-latest.xml
 <string>: Line 479: IDREF attribute target references an unknown ID "RFC4122"
 <string>: Line 776: IDREF attribute target references an unknown ID "ciphersuit-registry"
Makefile:4: recipe for target 'draft-ietf-teep-protocol-latest.txt' failed
make: *** [draft-ietf-teep-protocol-latest.txt] Error 1
```