### PR TITLE
Fix order, mandatory member in front of options for CBOR parsing

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1157,6 +1157,7 @@ teep-success = [
 teep-error = [
   type: TEEP-TYPE-teep-error,
   token: uint,
+  err-code: uint,
   options: {
      ? err-msg => text,
      ? supported-cipher-suites => [ + suite ],
@@ -1164,7 +1165,6 @@ teep-error = [
      * $$teep-error--extensions,
      * $$teep-option-extensions
   }
-  err-code: uint,
 ]
 
 supported-cipher-suites = 1


### PR DESCRIPTION
While attempt prototyping, found that mandatory member in teep-error was written after options in the draft.