### PR TITLE
Fix: error generating xml and txt by can not use numbering index after turning it off once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ $(FN).txt: $(FN).xml
 $(FN).xml: draft-ietf-teep-protocol.md
 	kramdown-rfc2629 draft-ietf-teep-protocol.md > $(FN).xml
 
+.PHONY: clean
+clean:
+	rm -fr $(FN).txt $(FN).xml

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1220,6 +1220,7 @@ suit-reports = 19
 {: numbered='no'}
 
 ### Some assumptions in examples
+{: numbered='no'}
 
 - OCSP stapling data = h'010203'
 - TEEP Device will have 2 TAs
@@ -1229,8 +1230,10 @@ suit-reports = 19
 - Not including Entity Attestation Token (EAT) parameters for example purposes
 
 ## QueryRequest Message
+{: numbered='no'}
 
 ### CBOR Diagnostic Notation
+{: numbered='no'}
 
 ~~~~
 / query-request = /
@@ -1251,6 +1254,7 @@ suit-reports = 19
 ~~~~
 
 ### CBOR Binary Representation
+{: numbered='no'}
 
 ~~~~
 84                        # array(4), 
@@ -1270,8 +1274,10 @@ suit-reports = 19
 ~~~~
 
 ## QueryResponse Message
+{: numbered='no'}
 
 ### CBOR Diagnostic Notation
+{: numbered='no'}
 
 ~~~~
 / query-response = /
@@ -1296,6 +1302,7 @@ suit-reports = 19
 ~~~~
 
 ### CBOR Binary Representation
+{: numbered='no'}
 
 ~~~~
 83                        # array(3)
@@ -1315,8 +1322,10 @@ suit-reports = 19
 ~~~~
 
 ## Install Message
+{: numbered='no'}
 
 ### CBOR Diagnostic Notation
+{: numbered='no'}
 
 ~~~~
 / install = /
@@ -1333,6 +1342,7 @@ suit-reports = 19
 ~~~~
 
 ### CBOR Binary Representation
+{: numbered='no'}
 
 ~~~~
 83                        # array(3)
@@ -1344,8 +1354,10 @@ suit-reports = 19
 ~~~~
 
 ## Success Message (for Install)
+{: numbered='no'}
 
 ### CBOR Diagnostic Notation
+{: numbered='no'}
 
 ~~~~
 / teep-success = /
@@ -1356,6 +1368,7 @@ suit-reports = 19
 ~~~~
 
 ### CBOR Binary Representation
+{: numbered='no'}
 
 ~~~~
 83                        # array(3)
@@ -1365,8 +1378,10 @@ suit-reports = 19
 
 
 ## Error Message (for Install)
+{: numbered='no'}
 
 ### CBOR Diagnostic Notation
+{: numbered='no'}
 
 ~~~~
 / teep-error = /
@@ -1384,6 +1399,7 @@ suit-reports = 19
 ~~~~
 
 ### CBOR binary Representation
+{: numbered='no'}
 
 ~~~~
 83                        # array(3)


### PR DESCRIPTION
Fixes errors when generating xml and txt from md by my examples commit in the past.

The error message:
xml2rfc draft-ietf-teep-protocol-latest.xml
/teep-protocol/draft-ietf-teep-protocol-latest.xml(1472): Error: Did not expect a numbered section under an unnumbered parent section (seen on line 1470)
/teep-protocol/draft-ietf-teep-protocol-latest.xml(1489): Error: Did not expect a numbered section under an unnumbered parent section (seen on line 1470)
/teep-protocol/draft-ietf-teep-protocol-latest.xml(1533): Error: Did not expect a numbered section under an unnumbered parent section (seen on line 1470)
/teep-protocol/draft-ietf-teep-protocol-latest.xml(1577): Error: Did not expect a numbered section under an unnumbered parent section (seen on line 1470)
/teep-protocol/draft-ietf-teep-protocol-latest.xml(1609): Error: Did not expect a numbered section under an unnumbered parent section (seen on line 1470)
/teep-protocol/draft-ietf-teep-protocol-latest.xml(1632): Error: Did not expect a numbered section under an unnumbered parent section (seen on line 1470)
/teep-protocol/draft-ietf-teep-protocol-latest.xml(16): Warning: Setting consensus="true" for IETF STD document (this is not the schema default, but is the only value permitted for this type of document)
Not creating output file due to errors (see above)
Unable to complete processing draft-ietf-teep-protocol-latest.xml

After this PR:xml2rfc draft-ietf-teep-protocol-latest.xml
/teep-protocol/draft-ietf-teep-protocol-latest.xml(16): Warning: Setting consensus="true" for IETF STD document (this is not the schema default, but is the only value permitted for this type of document)
/teep-protocol/draft-ietf-teep-protocol-latest.xml(1554): Warning: Artwork too wide, reducing indentation from 3 to 1
/teep-protocol/draft-ietf-teep-protocol-latest.xml(24): Warning: Postal address part filled in, but not used: <region>: Tirol
