### PR TITLE
[Hackathon] Make tc-list mandatory if trusted-components bit is set

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -486,7 +486,9 @@ evidence
 
 tc-list
 : The tc-list parameter enumerates the Trusted Components installed on the device
-  in the form of tc-info objects.
+  in the form of tc-info objects.  This parameter MUST be present if the
+  QueryResponse is sent in response to a QueryRequest with the
+  trusted-components bit set.
 
 requested-tc-list
 : The requested-tc-list parameter enumerates the Trusted Components that are


### PR DESCRIPTION
For consistency with the evidence being mandatory if attestation bit is
set

Addresses #80

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>