### PR TITLE
Fix array number in hex

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1205,7 +1205,7 @@ token = 20
 {: numbered='no'}
 
 ~~~~
-84                        # array(4), 
+83                        # array(3),
    01                     # unsigned(1)
    A4                     # map(4)
       14                  # unsigned(20)
@@ -1254,7 +1254,7 @@ token = 20
 {: numbered='no'}
 
 ~~~~
-83                        # array(3)
+82                        # array(2)
    02                     # unsigned(2)
    A4                     # map(4)
       14                  # unsigned(20)
@@ -1297,7 +1297,7 @@ token = 20
 {: numbered='no'}
 
 ~~~~
-83                        # array(3)
+82                        # array(2)
    03                     # unsigned(3)
    A2                     # map(2)
       14                  # unsigned(20)
@@ -1360,7 +1360,7 @@ token = 20
 {: numbered='no'}
 
 ~~~~
-84                        # array(4)
+83                        # array(3)
     06                    # unsigned(6)
     A1                    # map(1)
        14                 # unsigned(20)


### PR DESCRIPTION
After we change the token entry in teep message from mandatory entry to option entry, the numbers of entry in array have decreased.
This PR reflects the changes in binary representation.
@dthaler  Do you mind reviewing this PR?