### PR TITLE
Fix error when generating xml from md from mismatch year

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -17,7 +17,7 @@ abbrev: TEEP Protocol
 area: Security
 wg: TEEP
 kw: Trusted Execution Environment
-date: 2020
+date: 2021
 author:
 
  -


### PR DESCRIPTION
This fixes the error when generating xml and txt file from md file.
This is the error message if it has the year 2020.
```
$ make
kramdown-rfc2629 draft-ietf-teep-protocol.md > draft-ietf-teep-protocol-latest.xml
---
- 'No link definition for link ID ''[tbd: this rfc]'' found on line 1000'
- 'No link definition for link ID ''tbd: this rfc'' found on line 1000'
- 'No link definition for link ID ''[tbd: this rfc]'' found on line 1002'
- 'No link definition for link ID ''tbd: this rfc'' found on line 1002'
- No link definition for link ID ' 0x0102030405060708090a0b0c0d0e0f ' found on line
  1304
- No link definition for link ID ' 0x1102030405060708090a0b0c0d0e0f ' found on line
  1305
Incorrect section nesting: Need to start with 1
xml2rfc draft-ietf-teep-protocol-latest.xml
/home/akirat/projects/ietf/teep-protocol/draft-ietf-teep-protocol-latest.xml(16): Warning: Setting consensus="true" for IETF STD document (this is not the schema default, but is the only value permitted for this type of document)
/home/akirat/projects/ietf/teep-protocol/draft-ietf-teep-protocol-latest.xml(18): Error: Expected <date> to have the current year when month is missing, but found '2020'
Unable to complete processing draft-ietf-teep-protocol-latest.xml
Makefile:4: recipe for target 'draft-ietf-teep-protocol-latest.txt' failed
make: *** [draft-ietf-teep-protocol-latest.txt] Error 1
```

@dthaler appreciate for merging
