### PR TITLE
Token expiration description added

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -337,7 +337,8 @@ token
   to distinguish the correct response from multiple requests.
   The token value MUST NOT be used for other purposes, such as a TAM to
   identify the devices and/or a device to identify TAMs or Trusted Components.
-  The TAM MUST expire the token value after receiving the first responce
+  The TAM should set the expiration term to each token and MUST ignore expired tokens.
+  The TAM MUST expire the token value after receiving the first response
   from the device and ignore any subsequent messages that have the same token
   value.
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -337,7 +337,7 @@ token
   to distinguish the correct response from multiple requests.
   The token value MUST NOT be used for other purposes, such as a TAM to
   identify the devices and/or a device to identify TAMs or Trusted Components.
-  The TAM should set the expiration term to each token and MUST ignore expired tokens.
+  The TAM SHOULD set the expiration term to each token and MUST ignore any messages with expired tokens.
   The TAM MUST expire the token value after receiving the first response
   from the device and ignore any subsequent messages that have the same token
   value.


### PR DESCRIPTION
This PR is for #83 regarding token expiration.
- token having unlimited duration may be not secure, and not scalable for the TAM
- After the expiration term the TAM must ignore any messages with the expired token

This PR adds description of these considerations.