### PR TITLE
Remove obsolete paragraph from abstract

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -100,10 +100,6 @@ Trusted Applications (TAs) in a device with a Trusted Execution
 Environment (TEE).  This specification defines an interoperable
 protocol for managing the lifecycle of TAs.
 
-The protocol name is pronounced teepee. This conjures an image of a
-wedge-shaped protective covering for one's belongings, which sort of
-matches the intent of this protocol.
-
 --- middle
 
 # Introduction {#introduction}


### PR DESCRIPTION
Was true when the doc had TEEP-P but not when we dropped the -P

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>