### PR TITLE
Remove suit-commands bit

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -353,10 +353,6 @@ data-item-requested
      and extensions, which allows a TAM to discover the capabilities of a TEEP
      Agent implementation.
 
-   suit-commands (8)
-   : With this value the TAM queries the TEEP Agent for supported commands offered
-     by the SUIT manifest implementation.
-  
    Further values may be added in the future via IANA registration.
 
 supported-cipher-suites
@@ -1229,8 +1225,6 @@ trusted-components = 2
 $data-item-requested /= trusted-components
 extensions = 4
 $data-item-requested /= extensions
-suit-commands = 8
-$data-item-requested /= suit-commands
 
 query-request = [
   type: TEEP-TYPE-query-request,


### PR DESCRIPTION
Per IETF 111 [discussion](https://notes.ietf.org/notes-ietf-111-teep).  Just use SUIT reports to discover lack of such support when an error occurs.

Addresses issue #145

Signed-off-by: Dave Thaler <dthaler@microsoft.com>