### PR TITLE
Fixing typo in QueryResponse requested-tc-list

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -469,7 +469,7 @@ requested-tc-list
   as a dependency, or by a Trusted Application that has another Trusted
   Component as a dependency.  Requested Trusted Components are expressed in
   the form of requested-tc-info objects.
-  A TEEP Agent can get this information from the UnrequestTA conceptual API
+  A TEEP Agent can get this information from the RequestTA conceptual API
   defined in {{I-D.ietf-teep-architecture}} section 6.2.1.
 
 unneeded-tc-list


### PR DESCRIPTION
This PR fixes the explanation of QueryResponse requested-tc-list.
I think it is derived from REE's RequestTA API call.