### PR TITLE
Ciphersuite

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1175,8 +1175,6 @@ suite = [
 
 suites is used to present the combination of mechanisms and cryptographic algorithms.
 Each suite value corresponds with a COSE-type defined in Section 2 of {{RFC8152}}.
-If a TAM and TEEP agent indicate that it supports a certain mechanisms, it sets supporting algorithm's identifier as a value of mechanisms' key.
-Null in the value of mechanisms' key are treated as unable handling mechanism in the entity.
 
 ~~~~
 supported-cipher-suites = [ + suite ]

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1196,7 +1196,7 @@ teep-cose-encrypt-algs = cose-alg-accm-16-64-128
 teep-cose-mac-algs = cose-alg-hmac-256
 ~~~~
 
-TAM and TEEP Agents MAY use these algorithms:
+A TAM or TEEP Agent MAY also support one or more of the following algorithms:
 
 ~~~~
 teep-cose-sign-algs = 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1184,7 +1184,7 @@ supported-cipher-suites = [ + suite ]
 
 To show supported ciphersuites in QueryRequest or Error messages, make an array of ciphersuite structures. If an entity supports multiple mechanisms and algorithms, it can choose the specific combinations or all combinations by picking values in the array.
 
-Each cryptographic algorithm value depends on COSE Algorithm registry defined by {{COSE.Algorithm}}.
+Cryptographic algorithm values are defined in the COSE Algorithms registry {{COSE.Algorithm}}.
 And TEEP protocol defines highly recommended algorithms lists to implement TAM and TEEP Agents as following list.
 TAM and TEEP Agents SHOULD implement these algorithms. TEEP Agents MAY support either-or algorithms in signature mechanism.
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1127,69 +1127,49 @@ After QueryResponse, the selected cryptographic algorithm is used in the TEEP me
 To negotiate the chosing cryptographic mechanisms and algorithms, TEEP protocol defines the ciphersuite structure.
 
 ~~~~
-supported-cipher-suites = [
-    [ *teep-cose-sign-alg ] ,
-    [ *teep-cose-encrypt-alg ] ,
-    [ *teep-cose-mac-alg ] 
-]
-~~~~
-
-supported-cipher-suites is used to present supported mechanisms and algorithms in QueryRequest and Error.
-Each keys correspond with COSE message Objects.
-If the TAM and TEEP agents indicate that it supports a certain mechanisms, it sets supporting algorithm's array as a value of mechanisms' key.
-Empty array in the value of mechanisms' key are treated as unable handling mechanism in the entity.
-
-~~~~
-selected-cipher-suites = [
+suites = [
     teep-cose-sign-alg / nil,
-    teep-cose-encrypt-alg / nil,
-    teep-cose-mac-alg / nil
+    teep-cose-encrypt-alg / nil ,
+    teep-cose-mac-alg / nil 
 ]
 ~~~~
 
-selected-cipher-suites is used to present selected mechanisms and algorithm sets chosen from supported-cipher-suites.
-Each keys correspond with COSE message Objects.
-Null in the value of mechanism indicates that the entity doesn't support the mechanism.
+suites is used to present the combination of mechanisms and cryptographic algorithms.
+Each keys correspond with COSE-type defined in the Section 2 of {{RFC8152}}.
+If a TAM and TEEP agent indicate that it supports a certain mechanisms, it sets supporting algorithm's identifier as a value of mechanisms' key.
+Null in the value of mechanisms' key are treated as unable handling mechanism in the entity.
 
-After QueryResponse, the selected cryptographic algorithm is used in the TEEP messages: Install, Success and Error.
+~~~~
+supported-cipher-suites = [ + suite ]
+~~~~
 
-In algorithm array, each algorithm value depends on COSE Algorithm registry defined by {{COSE.Algorithm}}.
+To show supported ciphersuites in QueryRequest or Error messages, make an array of ciphersuite structures. If an entity supports multiple mechanisms and algorithms, it can choose the specific combinations or all combinations by picking values in the array.
+
+Each cryptographic algorithm value depends on COSE Algorithm registry defined by {{COSE.Algorithm}}.
 And TEEP protocol defines highly recommended algorithms lists to implement TAM and TEEP Agents as following list.
 TAM and TEEP Agents SHOULD implement these algorithms. TEEP Agents MAY support either-or algorithms in signature mechanism.
 
 ~~~~
-teep-cose-sign-algs = [
-    cose-alg-es256,
-    cose-alg-eddsa
-]
+teep-cose-sign-algs = cose-alg-es256 / cose-alg-eddsa
 
-teep-cose-encrypt-algs = [
-    cose-alg-accm-16-64-128
-]
+teep-cose-encrypt-algs = cose-alg-accm-16-64-128
 
-teep-cose-mac-algs = [
-    cose-alg-hmac-256
-]
+teep-cose-mac-algs = cose-alg-hmac-256
 ~~~~
 
 TAM and TEEP Agents MAY use these algorithms:
 
 ~~~~
-teep-cose-sign-algs = [
-    cose-alg-ps256,
-    cose-alg-ps384,
-    cose-alg-ps512,
-    cose-alg-rsa-oaep-256
+teep-cose-sign-algs = 
+    cose-alg-ps256/
+    cose-alg-ps384/
+    cose-alg-ps512/
+    cose-alg-rsa-oaep-256/
     cose-alg-rsa-oaep-512
-]
 
-teep-cose-encrypt-algs = [
-    //TBD
-]
+teep-cose-encrypt-algs = TBD
 
-teep-cose-mac-algs = [
-    //TBD
-]
+teep-cose-mac-algs = TBD
 ~~~~
 
 Any ciphersuites without confidentiality protection can only be added if the associated specification includes a discussion of security considerations and applicability, since manifests may carry sensitive information. For example, Section 6 of {{I-D.ietf-teep-architecture}} permits implementations that terminate transport security inside the TEE and if the transport security provides confidentiality then additional encryption might not be needed in the manifest for some use cases. For most use cases, however, manifest confidentiality will be needed to protect sensitive fields from the TAM as discussed in Section 9.8 of {{I-D.ietf-teep-architecture}}.
@@ -1476,13 +1456,7 @@ query-request = [
 ]
 
 ; ciphersuites
-supported-cipher-suites = [
-    [ *teep-cose-sign-alg ],
-    [ *teep-cose-encrypt-alg ] ,
-    [ *teep-cose-mac-alg ] 
-]
-
-selected-cipher-suites = [
+suite = [
     teep-cose-sign-alg / nil,
     teep-cose-encrypt-alg / nil,
     teep-cose-mac-alg / nil

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -87,10 +87,10 @@ normative:
   I-D.moran-suit-trust-domains: 
   I-D.moran-suit-report: 
   COSE.Algorithm:
-    title: "CBOR Object Signing and Encryption (COSE)"
+    title: "COSE Algorithms"
     author:
       org: IANA
-    target: https://www.iana.org/assignments/cose/cose.xhtml
+    target: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 informative:
   I-D.ietf-teep-architecture: 
   I-D.birkholz-rats-suit-claims:
@@ -1166,14 +1166,14 @@ After a QueryResponse is received, the selected cryptographic algorithm is used 
 To negotiate cryptographic mechanisms and algorithms, the TEEP protocol defines the following ciphersuite structure.
 
 ~~~~
-suite = [
+ciphersuite = [
     teep-cose-sign-alg / nil,
     teep-cose-encrypt-alg / nil ,
     teep-cose-mac-alg / nil 
 ]
 ~~~~
 
-suites is used to present the combination of mechanisms and cryptographic algorithms.
+ciphersuite is used to present the combination of mechanisms and cryptographic algorithms.
 Each suite value corresponds with a COSE-type defined in Section 2 of {{RFC8152}}.
 
 ~~~~

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1128,7 +1128,7 @@ After QueryResponse, the selected cryptographic algorithm is used in the TEEP me
 To negotiate the chosing cryptographic mechanisms and algorithms, TEEP protocol defines the ciphersuite structure.
 
 ~~~~
-suites = [
+suite = [
     teep-cose-sign-alg / nil,
     teep-cose-encrypt-alg / nil ,
     teep-cose-mac-alg / nil 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1182,8 +1182,6 @@ Null in the value of mechanisms' key are treated as unable handling mechanism in
 supported-cipher-suites = [ + suite ]
 ~~~~
 
-To show supported ciphersuites in QueryRequest or Error messages, make an array of ciphersuite structures. If an entity supports multiple mechanisms and algorithms, it can choose the specific combinations or all combinations by picking values in the array.
-
 Cryptographic algorithm values are defined in the COSE Algorithms registry {{COSE.Algorithm}}.
 A TAM MUST support both of the following ciphersuites.  A TEEP Agent MUST support at least
 one of the two but can choose which one.  For example, a TEEP Agent might

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -17,7 +17,7 @@ abbrev: TEEP Protocol
 area: Security
 wg: TEEP
 kw: Trusted Execution Environment
-date: 2021
+date: 2022
 author:
 
  -
@@ -1847,7 +1847,10 @@ bz/m4rVlnIXbwK07HypLbAmBMcCjbazR14vTgdzfsJwFLbM5kdtzOLSolg==
 ~~~~
 
 ## Example 1: SUIT Manifest pointing to URI of the Trusted Component Binary {#suit-uri}
+{: numbered='no'}
+
 ### CBOR Diagnostic Notation of SUIT Manifest
+{: numbered='no'}
 
 ~~~~
 / SUIT_Envelope_Tagged / 107 ( {
@@ -1915,6 +1918,7 @@ bz/m4rVlnIXbwK07HypLbAmBMcCjbazR14vTgdzfsJwFLbM5kdtzOLSolg==
 
 
 ### CBOR Binary Representation
+{: numbered='no'}
 
 ~~~~
 D8 6B                                               # tag(107) / SUIT_Envelope_Tagged /
@@ -2017,6 +2021,7 @@ D8 6B                                               # tag(107) / SUIT_Envelope_T
 
 
 ### CBOR Binary in Hex
+{: numbered='no'}
 
 ~~~~
 D86BA2025873825824822F58208ADC995573631639C3C6D5FC4026160C8A
@@ -2037,7 +2042,10 @@ A115783668747470733A2F2F74632E6F72672F38643832353733612D3932
 
 
 ## Example 2: SUIT Manifest including the Trusted Component Binary {#suit-integrated}
+{: numbered='no'}
+
 ### CBOR Diagnostic Notation of SUIT Manifest
+{: numbered='no'}
 
 ~~~~
 / SUIT_Envelope_Tagged / 107 ( {
@@ -2106,6 +2114,7 @@ A115783668747470733A2F2F74632E6F72672F38643832353733612D3932
 
 
 ### CBOR Binary Representation
+{: numbered='no'}
 
 ~~~~
 D8 6B                                               # tag(107) / SUIT_Envelope_Tagged /
@@ -2212,6 +2221,7 @@ D8 6B                                               # tag(107) / SUIT_Envelope_T
 
 
 ### CBOR Binary in Hex
+{: numbered='no'}
 
 ~~~~
 D86BA3025873825824822F5820C8363BDF3DCF68F0234A9DD320C2FEA72D
@@ -2231,8 +2241,10 @@ B77A30D046397481469468ECE80E14010F020F094C8613A1156323746315
 
 
 ## Example 3: Supplying Personalization Data for Trusted Component Binary {#suit-personalization}
+{: numbered='no'}
 
 ### CBOR Diagnostic Notation of SUIT Manifest
+{: numbered='no'}
 
 ~~~~
 / SUIT_Envelope_Tagged / 107 ( {
@@ -2322,6 +2334,7 @@ B77A30D046397481469468ECE80E14010F020F094C8613A1156323746315
 
 
 ### CBOR Binary Represenation
+{: numbered='no'}
 
 ~~~~
 D8 6B                                               # tag(107) / SUIT_Envelope_Tagged /
@@ -2457,6 +2470,7 @@ D8 6B                                               # tag(107) / SUIT_Envelope_T
 
 
 ### CBOR Binary in Hex
+{: numbered='no'}
 
 ~~~~
 D86BA2025873825824822F5820A810FBAFCAC8C7E107AD974DDC6FDB4D51
@@ -2480,6 +2494,7 @@ F7093D8C55BAA8C5265FC5820F4E035824822F5820AAABCCCDEEEF000122
 
 
 ## Delete a Trusted Component
+{: numbered='no'}
 
 This sample manifest removes a Trusted Component and its dependency.
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -362,7 +362,7 @@ data-item-requested
 
 supported-cipher-suites
 : The supported-cipher-suites parameter lists the ciphersuite(s) supported by the TAM. If this parameter is not present, it is to be treated the same as if
-  it contained all SHOULD ciphersuites defined in this document. Details
+  it contained all ciphersuites defined in this document that are listed as "MUST". Details
   about the ciphersuite encoding can be found in {{ciphersuite}}.
 
 supported-freshness-mechanisms

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1163,7 +1163,7 @@ or Error message is generated only after completing the Update Procedure.
 
 The TEEP protocol uses COSE for protection of TEEP messages.
 After a QueryResponse is received, the selected cryptographic algorithm is used in subsequent TEEP messages (Install, Success, and Error).
-To negotiate the chosing cryptographic mechanisms and algorithms, TEEP protocol defines the ciphersuite structure.
+To negotiate cryptographic mechanisms and algorithms, the TEEP protocol defines the following ciphersuite structure.
 
 ~~~~
 suite = [

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1162,7 +1162,7 @@ or Error message is generated only after completing the Update Procedure.
 # Ciphersuites {#ciphersuite}
 
 The TEEP protocol uses COSE for protection of TEEP messages.
-After QueryResponse, the selected cryptographic algorithm is used in the TEEP messages: Install, Success and Error.
+After a QueryResponse is received, the selected cryptographic algorithm is used in subsequent TEEP messages (Install, Success, and Error).
 To negotiate the chosing cryptographic mechanisms and algorithms, TEEP protocol defines the ciphersuite structure.
 
 ~~~~

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1185,8 +1185,9 @@ supported-cipher-suites = [ + suite ]
 To show supported ciphersuites in QueryRequest or Error messages, make an array of ciphersuite structures. If an entity supports multiple mechanisms and algorithms, it can choose the specific combinations or all combinations by picking values in the array.
 
 Cryptographic algorithm values are defined in the COSE Algorithms registry {{COSE.Algorithm}}.
-And TEEP protocol defines highly recommended algorithms lists to implement TAM and TEEP Agents as following list.
-TAM and TEEP Agents SHOULD implement these algorithms. TEEP Agents MAY support either-or algorithms in signature mechanism.
+A TAM MUST support both of the following ciphersuites.  A TEEP Agent MUST support at least
+one of the two but can choose which one.  For example, a TEEP Agent might
+choose a given ciphersuite if it has hardware support for it.
 
 ~~~~
 teep-cose-sign-algs = cose-alg-es256 / cose-alg-eddsa

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1174,7 +1174,7 @@ suite = [
 ~~~~
 
 suites is used to present the combination of mechanisms and cryptographic algorithms.
-Each keys correspond with COSE-type defined in the Section 2 of {{RFC8152}}.
+Each suite value corresponds with a COSE-type defined in Section 2 of {{RFC8152}}.
 If a TAM and TEEP agent indicate that it supports a certain mechanisms, it sets supporting algorithm's identifier as a value of mechanisms' key.
 Null in the value of mechanisms' key are treated as unable handling mechanism in the entity.
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1513,7 +1513,7 @@ teep-cose-encrypt-alg /= cose-alg-accm-16-64-128
 
 teep-cose-mac-alg /= cose-alg-hmac-256
 
-; algorithm identifier defined by IANA COSE Algorithm Registry
+; algorithm identifiers defined in the IANA COSE Algorithms Registry
 cose-alg-es256 = -7
 cose-alg-eddsa = -8
 cose-alg-ps256 = -37

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1200,10 +1200,10 @@ TAM and TEEP Agents MAY use these algorithms:
 
 ~~~~
 teep-cose-sign-algs = 
-    cose-alg-ps256/
-    cose-alg-ps384/
-    cose-alg-ps512/
-    cose-alg-rsa-oaep-256/
+    cose-alg-ps256 /
+    cose-alg-ps384 /
+    cose-alg-ps512 /
+    cose-alg-rsa-oaep-256 /
     cose-alg-rsa-oaep-512
 
 teep-cose-encrypt-algs = TBD

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1161,7 +1161,7 @@ or Error message is generated only after completing the Update Procedure.
 
 # Ciphersuites {#ciphersuite}
 
-TEEP protocol uses COSE as protection mechanisms of TEEP messages.
+The TEEP protocol uses COSE for protection of TEEP messages.
 After QueryResponse, the selected cryptographic algorithm is used in the TEEP messages: Install, Success and Error.
 To negotiate the chosing cryptographic mechanisms and algorithms, TEEP protocol defines the ciphersuite structure.
 


### PR DESCRIPTION
Related to #167.

This PR contains following modify about ciphersuite
* Define `suite` structure. 'suite' is an array and has three algorithm identifiers correspond with three mechanisms; sign, encrypt and MAC.
* Remove the IANA request for TEEP ciphersuites. Instead of this, declare that algorithm identifiers depends on COSE Algorithm registry.
* Define MTI algorithms and other available sign algorithms from former ciphersuites and discussion.   Encrypt and MAC available algorithms are TBD due to no discussion about this currently.
* Minor fix to build the draft. (update new year, insert 'no' numbered)