### PR TITLE
Use hwmodel claim added in EAT draft-12

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -93,7 +93,6 @@ normative:
     target: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 informative:
   I-D.ietf-teep-architecture: 
-  I-D.birkholz-rats-suit-claims:
   RFC8610: 
   RFC8126: 
   RFC8915: 
@@ -543,9 +542,9 @@ requirements:
 | Requirement  | Claim | Reference |
 | Device unique identifier | ueid | {{I-D.ietf-rats-eat}} section 3.4 |
 | Vendor of the device | oemid | {{I-D.ietf-rats-eat}} section 3.6 |
-| Class of the device | class-identifier | {{I-D.birkholz-rats-suit-claims}} section 3.1.2 |
-| TEE hardware type | chip-version | {{I-D.ietf-rats-eat}} section 3.7 |
-| TEE hardware version | chip-version | {{I-D.ietf-rats-eat}} section 3.7 |
+| Class of the device | hwmodel | {{I-D.ietf-rats-eat}} section 3.7 |
+| TEE hardware type | chip-version | {{I-D.ietf-rats-eat}} section 3.8 |
+| TEE hardware version | chip-version | {{I-D.ietf-rats-eat}} section 3.8 |
 | TEE firmware type | sw-name | {{I-D.ietf-rats-eat}} section 3.9 |
 | TEE firmware version | sw-version | {{I-D.ietf-rats-eat}} section 3.10 |
 | Freshness proof | nonce | {{I-D.ietf-rats-eat}} section 3.3 |


### PR DESCRIPTION
The hwmodel claim is newly added to EAT as shown in https://www.ietf.org/rfcdiff?url2=draft-ietf-rats-eat-12.txt

This PR proposes to use it to meet the "class of device" requirement in the teep arch doc.   If we later find it is not sufficient, we can always add an extension once it is shown to be needed.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>