### PR TITLE
Removing SUIT_Envelope in TEEP Protocol CDDL

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1532,8 +1532,6 @@ specified in {{I-D.ietf-suit-manifest}}.
 ~~~~
 teep-message = $teep-message-type .within teep-message-framework
 
-SUIT_Envelope = any
-
 teep-message-framework = [
   type: uint (0..23) / $teep-type-extension,
   options: { * teep-option },


### PR DESCRIPTION
The CDDL of SUIT_Envelope is defined in I-D.ietf-suit-manifest precisely, which conflicts here.
