### PR TITLE
Clarify use of Attestation Results

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -148,6 +148,9 @@ and/or configuration data and keys needed by a TA to operate correctly.
 Each Trusted Component is uniquely identified by a SUIT Component Identifier
 (see {{I-D.ietf-suit-manifest}} Section 8.7.2.2).
 
+Attestation related terms, such as Evidence and Attestation Results,
+are as defined in {{I-D.ietf-rats-architecture}}.
+
 # Message Overview {#messages}
 
 The TEEP protocol consists of messages exchanged between a TAM
@@ -346,8 +349,8 @@ data-item-requested
   specification defines the following initial set of information elements:
 
    attestation (1)
-   : With this value the TAM requests the TEEP Agent to return attestation
-     evidence (e.g., an EAT) in the response.
+   : With this value the TAM requests the TEEP Agent to return an attestation payload,
+     whether Evidence (e.g., an EAT) or Attestation Results, in the response.
 
    trusted-components (2)
    : With this value the TAM queries the TEEP Agent for all installed Trusted Components.
@@ -375,7 +378,7 @@ supported-freshness-mechanisms
 
 challenge
 : The challenge field is an optional parameter used for ensuring the freshness of the
-  attestation evidence returned with a QueryResponse message. It MUST be absent if
+  attestation payload returned with a QueryResponse message. It MUST be absent if
   the attestation bit is clear (since the token is used instead in that case).
   When a challenge is 
   provided in the QueryRequest and an EAT is returned with a QueryResponse message
@@ -410,8 +413,8 @@ query-response = [
     ? token => bstr .size (8..64),
     ? selected-cipher-suite => ciphersuite,
     ? selected-version => version,
-    ? evidence-format => text,
-    ? evidence => bstr,
+    ? attestation-payload-format => text,
+    ? attestation-payload => bstr,
     ? suit-reports => [ + suit-report ],
     ? tc-list => [ + tc-info ],
     ? requested-tc-list => [ + requested-tc-info ],
@@ -457,18 +460,18 @@ selected-version
   TEEP Agent. The absence of this parameter indicates the same as if it
   was present with a value of 0.
 
-evidence-format
-: The evidence-format parameter indicates the IANA Media Type of the
-  attestation evidence contained in the evidence parameter.  It MUST be
-  present if the evidence parameter is present and the format is not an EAT.
+attestation-payload-format
+: The attestation-payload-format parameter indicates the IANA Media Type of the
+  attestation-payload parameter.  It MUST be
+  present if the attestation-payload parameter is present and the format is not an EAT.
 
-evidence
-: The evidence parameter contains the attestation evidence.  This parameter
+attestation-payload
+: The attestation-payload parameter contains Evidence or Attestation Results.  This parameter
   MUST be present if the QueryResponse is sent in response to a QueryRequest
-  with the attestation bit set.  If the evidence-format parameter is absent,
-  the attestation evidence contained in this parameter MUST be
+  with the attestation bit set.  If the attestation-payload-format parameter is absent,
+  the attestation payload contained in this parameter MUST be
   an Entity Attestation Token following the encoding
-  defined in {{I-D.ietf-rats-eat}}.  See {{evidence}} for further discussion.
+  defined in {{I-D.ietf-rats-eat}}.  See {{attestation}} for further discussion.
 
 suit-reports
 : If present, the suit-reports parameter contains a set of "boot" (including
@@ -541,12 +544,12 @@ have-binary
   that authorizes installing it.  If have-binary is true, the
   tc-manifest-sequence-number field MUST be present.
 
-### Evidence and Attestation Results {#evidence}
+### Evidence and Attestation Results {#attestation}
 
 Section 7 of {{I-D.ietf-teep-architecture}} lists information that may appear
-in evidence depending on the circumstance.  However, the evidence is
+in Evidence depending on the circumstance.  However, the Evidence is
 opaque to the TEEP protocol and there are no formal requirements on the contents
-of evidence.
+of Evidence.
 
 TAMs however consume Attestation Results and do need enough information therein to
 make decisions on how to remediate a TEE that is out of compliance, or update a TEE
@@ -554,7 +557,8 @@ that is requesting an authorized change.  To do so, the information in
 Section 7 of {{I-D.ietf-teep-architecture}} is often required depending on the policy.
 When an Entity
 Attestation Token is used, the following claims can be used to meet those
-requirements:
+requirements, whether these claims appear in Attestation Results, or in Evidence
+for the Verifier to use when generating Attestation Results of some form:
 
 | Requirement  | Claim | Reference |
 | Device unique identifier | ueid | {{I-D.ietf-rats-eat}} section 3.4 |
@@ -621,7 +625,7 @@ The TAM is what authorizes
 apps to be installed, updated, and deleted on a given TEE and so the TEEP
 signature is checked by the TEEP Agent at protocol message processing time.
 (This same TEEP security wrapper is also used on messages like QueryRequest
-so that Agents only send potentially sensitive data such as evidence to
+so that Agents only send potentially sensitive data such as Evidence to
 trusted TAMs.)
 
 The Trusted Component signer on the other hand is what authorizes the
@@ -993,8 +997,7 @@ ERR_PERMANENT_ERROR (1)
   A TAM receiving this error might refuse to communicate further with
   the TEEP Agent for some period of time until it has reason to believe
   it is worth trying again, but it should take care not to give up on
-  communication when there is no attestation evidence indicating that
-  the error is genuine.  In contrast, ERR_TEMPORARY_ERROR is an indication
+  communication.  In contrast, ERR_TEMPORARY_ERROR is an indication
   that a more agressive retry is warranted.
 
 ERR_UNSUPPORTED_EXTENSION (2)
@@ -1060,9 +1063,9 @@ behavioral difference is expected to be.
 The TEEP protocol operates between a TEEP Agent and a TAM.  While
 the TEEP protocol does not require use of EAT, use of EAT is encouraged and
 {{query-response}} explicitly defines a way to carry an Entity Attestation Token
-evidence in a QueryResponse.  
+in a QueryResponse.  
 
-As discussed in {{evidence}}, the content of attestation evidence is opaque to the TEEP
+As discussed in {{attestation}}, the content of Evidence is opaque to the TEEP
 architecture, but the content of Attestation Results is not, where Attestation
 Results flow between a Verifier and a TAM (as the Relying Party).
 Although Attestation Results required by a TAM are separable from the TEEP protocol
@@ -1094,7 +1097,7 @@ of this document.)
 * Freshness: See {{freshness-mechanisms}}.
 * Required Claims: None.
 * Prohibited Claims: None.
-* Additional Claims: Optional claims are those listed in {{evidence}}.
+* Additional Claims: Optional claims are those listed in {{attestation}}.
 * Refined Claim Definition: None.
 * CBOR Tags: CBOR Tags are not used.
 * Manifests and Software Evidence Claims: The sw-name claim for a Trusted
@@ -1116,13 +1119,13 @@ This specification uses the following mapping:
 | version                        |     3 |
 | selected-cipher-suite          |     5 |
 | selected-version               |     6 |
-| evidence                       |     7 |
+| attestation-payload            |     7 |
 | tc-list                        |     8 |
 | ext-list                       |     9 |
 | manifest-list                  |    10 |
 | msg                            |    11 |
 | err-msg                        |    12 |
-| evidence-format                |    13 |
+| attestation-payload-format     |    13 |
 | requested-tc-list              |    14 |
 | unneeded-tc-list               |    15 |
 | component-id                   |    16 |
@@ -1161,10 +1164,10 @@ was present.  If these requirements are not met, the TAM drops the message.  It 
 additional implementation specific actions such as logging the results.  If the requirements
 are met, processing continues as follows.
 
-If a QueryResponse message is received that contains that contains evidence, the evidence
+If a QueryResponse message is received that contains that contains Evidence, the Evidence
 is passed to an attestation Verifier (see {{I-D.ietf-rats-architecture}})
-to determine whether the Agent is in a trustworthy state.  Once the TAM receives Attestation Results
-from the Verifier, processing continues as follows.
+to determine whether the Agent is in a trustworthy state.  Once the TAM receives Attestation
+Results, processing continues as follows.
 
 Based on the results of attestation (if any), any SUIT Reports,
 and the lists of installed, requested,
@@ -1303,7 +1306,7 @@ discussed in Section 9.8 of {{I-D.ietf-teep-architecture}}.
 
 # Freshness Mechanisms {#freshness-mechanisms}
 
-A freshness mechanism determines how a TAM can tell whether evidence provided
+A freshness mechanism determines how a TAM can tell whether an attestation payload provided
 in a Query Response is fresh.  There are multiple ways this can be done
 as discussed in Section 10 of {{I-D.ietf-rats-architecture}}.
 
@@ -1316,11 +1319,11 @@ This document defines the following freshness mechanisms:
 |     2 | Timestamp                                      |
 |     3 | Epoch ID                                       |
 
-In the Nonce mechanism, the evidence MUST include a nonce provided
+In the Nonce mechanism, the attestation payload MUST include a nonce provided
 in the QueryRequest challenge.  In other mechanisms, a timestamp
 or epoch ID determined via mechanisms outside the TEEP protocol is
 used, and the challenge is only needed in the QueryRequest message
-if a challenge is needed in generating evidence for reasons other
+if a challenge is needed in generating the attestation payload for reasons other
 than freshness.
 
 If a TAM supports multiple freshness mechanisms that require different challenge
@@ -1345,16 +1348,21 @@ Cryptographic Algorithms
   and vice versa.
 
 Attestation
-: A TAM can rely on the attestation evidence provided by the TEEP
-  Agent.  To sign the attestation evidence, it is necessary
-  for the device to possess a public key (usually in the form of a
-  certificate {{RFC5280}}) along with the corresponding private key. Depending on
+: A TAM relies on signed Attestation Results provided by a Verifier,
+  either obtained directly using a mechanism outside the TEEP protocol
+  (by using some mechanism to pass Evidence obtained in the attestation payload of
+  a QueryResponse, and getting back the Attestation Results), or indirectly
+  via the TEEP Agent forwarding the Attestation Results in the attestation
+  payload of a QueryResponse. See the security considerations of the
+  specific mechanism in use (e.g., EAT) for more discussion.
+
+  Depending on
   the properties of the attestation mechanism, it is possible to
-  uniquely identify a device based on information in the attestation
-  evidence or in the certificate used to sign the attestation
-  evidence.  This uniqueness may raise privacy concerns. To lower the
-  privacy implications the TEEP Agent MUST present its attestation
-  evidence only to an authenticated and authorized TAM and when using
+  uniquely identify a device based on information in the
+  attestation payload or in the certificate used to sign the
+  attestation payload.  This uniqueness may raise privacy concerns. To lower the
+  privacy implications the TEEP Agent MUST present its
+  attestation payload only to an authenticated and authorized TAM and when using
   EATS, it SHOULD use encryption as discussed in {{I-D.ietf-rats-eat}}, since
   confidentiality is not provided by the TEEP protocol itself and
   the transport protocol under the TEEP protocol might be implemented
@@ -1641,7 +1649,7 @@ COSE is shown.
               1 (.within uint .size 4) /
     6 : 0,  / selected-version = 6 (mapkey) :
               0 (.within uint .size 4) /
-    7 : ... / evidence = 7 (mapkey) :
+    7 : ... / attestation-payload = 7 (mapkey) :
               Entity Attestation Token /
     8 : [   / tc-list = 8 (mapkey) : (array of tc-info) /
       {


### PR DESCRIPTION
Clarify that the Passport model is not illegal in TEEP even if it's not typical.

Fixes #185

Signed-off-by: Dave Thaler <dthaler@microsoft.com>