### PR TITLE
Hackathon feedback around ciphersuites

### DIFF
--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -140,7 +140,7 @@ teep-error = [
   options: {
      ? token => bstr .size (8..64),
      ? err-msg => text .size (1..128),
-     ? supported-cipher-suites => [ + $ciphersuite ],
+     ? supported-ciphersuites => [ + $ciphersuite ],
      ? supported-freshness-mechanisms => [ + freshness-mechanism ],
      ? versions => [ + version ],
      ? suit-reports => [ + SUIT_Report ],
@@ -162,7 +162,7 @@ ERR_TEMPORARY_ERROR = 10
 ERR_MANIFEST_PROCESSING_FAILED = 17
 
 ; labels of mapkey for teep message parameters, uint (0..23)
-supported-cipher-suites = 1
+supported-ciphersuites = 1
 challenge = 2
 versions = 3
 selected-cipher-suite = 5

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -38,7 +38,7 @@ query-request = [
   type: TEEP-TYPE-query-request,
   options: {
     ? token => bstr .size (8..64),
-    ? supported-cipher-suites => [ + $ciphersuite ],
+    ? supported-ciphersuites => [ + $ciphersuite ],
     ? supported-freshness-mechanisms => [ + freshness-mechanism ],
     ? challenge => bstr .size (8..512),
     ? versions => [ + version ],

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -38,7 +38,7 @@ query-request = [
   type: TEEP-TYPE-query-request,
   options: {
     ? token => bstr .size (8..64),
-    ? supported-cipher-suites => [ + ciphersuite ],
+    ? supported-cipher-suites => [ + $ciphersuite ],
     ? supported-freshness-mechanisms => [ + freshness-mechanism ],
     ? challenge => bstr .size (8..512),
     ? versions => [ + version ],
@@ -48,37 +48,30 @@ query-request = [
   data-item-requested: data-item-requested
 ]
 
-; For ciphersuites from this line
-COSE_Sign_Tagged     = 98
+;MANDATORY for TAM and TEEP Agent to support the following COSE
+;operations, and OPTIONAL to support additional ones such as
+;COSE_Sign_Tagged, COSE_Encrypt0_Tagged, etc.
+
 COSE_Sign1_Tagged    = 18
-COSE_Encrypt_Tagged  = 96
-COSE_Encrypt0_Tagged = 16
-COSE_Mac_Tagged      = 97
-COSE_Mac0_Tagged     = 17
 
-;RECOMMENDED to implement:
-cose-alg-hss-lms = -46
-teep-cose-algs /= cose-alg-hss-lms
+;MANDATORY for TAM to support the following, and OPTIONAL to implement
+;any additional algorithms from the IANA COSE Algorithms registry.
 
-;OPTIONAL to implement any from IANA cose registry. Listing only partially:
-cose-alg-es256 = -7
-cose-alg-eddsa = -8
-cose-alg-a256gcm = 3
-cose-alg-hmac-256-256 = 5
-cose-alg-hmac-384-385 = 6
-cose-alg-hmac-512-512 = 7
-teep-cose-algs /= cose-alg-es256
-teep-cose-algs /= cose-alg-eddsa
-teep-cose-algs /= cose-alg-a256gcm
-teep-cose-algs /= cose-alg-hmac-256-256
-teep-cose-algs /= cose-alg-hmac-384-385
-teep-cose-algs /= cose-alg-hmac-512-512
+cose-alg-eddsa = -8  ; EdDSA
+cose-alg-es256 = -7  ; ECDSA w/ SHA-256
 
-teep-cose-sign = [ COSE_Sign_Tagged / COSE_Sign1_Tagged, teep-cose-algs ]
-teep-cose-encrypt = [ COSE_Encrypt_Tagged / COSE_Encrypt0_Tagged, teep-cose-algs ]
-teep-cose-mac = [ COSE_Mac_Tagged / COSE_Mac0_Tagged, teep-cose-algs ]
+;MANDATORY for TAM to support the following ciphersuites, and OPTIONAL
+;to support any additional ones that use COSE_Sign_Tagged, or other
+;signing, encryption, or MAC algorithms.
 
-ciphersuite = [ * ( teep-cose-sign / teep-cose-encrypt / teep-cose-mac ) ]
+teep-operation-sign1-eddsa = [ COSE_Sign1_Tagged, cose-alg-eddsa ]
+teep-operation-sign1-es256 = [ COSE_Sign1_Tagged, cose-alg-es256 ]
+
+teep-ciphersuite-sign1-eddsa = [ teep-operation-sign1-eddsa ]
+teep-ciphersuite-sign1-es256 = [ teep-operation-sign1-es256 ]
+
+$ciphersuite /= teep-ciphersuite-sign1-eddsa
+$ciphersuite /= teep-ciphersuite-sign1-es256
 
 ; freshness-mechanisms
 
@@ -147,7 +140,7 @@ teep-error = [
   options: {
      ? token => bstr .size (8..64),
      ? err-msg => text .size (1..128),
-     ? supported-cipher-suites => [ + ciphersuite ],
+     ? supported-cipher-suites => [ + $ciphersuite ],
      ? supported-freshness-mechanisms => [ + freshness-mechanism ],
      ? versions => [ + version ],
      ? suit-reports => [ + SUIT_Report ],

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1593,10 +1593,10 @@ This section includes some examples with the following assumptions:
          A0A1A2A3A4A5A6A7A8A9AAABACADAEAF
       01            # unsigned(1) / supported-ciphersuites: /
       82            # array(2)
-         83         # array(2)
+         82         # array(2)
             12      # unsigned(18) / cose-sign1 /
             26      # negative(6) / -7 = cose-alg-es256 /
-         83         # array(2)
+         82         # array(2)
             12      # unsigned(18) / cose-sign1 /
             26      # negative(7) / -8 = cose-alg-eddsa /
       03            # unsigned(3) / versions: /
@@ -1671,7 +1671,7 @@ COSE is shown.
       50            # bytes(16)
          A0A1A2A3A4A5A6A7A8A9AAABACADAEAF
       05            # unsigned(5) / selected-ciphersuite: /
-      83            # array(2)
+      82            # array(2)
          12         # unsigned(18) / cose-sign1 /
          26         # negative(6) / -7 = cose-alg-es256 /
       06            # unsigned(6) / selected-version: /

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -83,7 +83,6 @@ normative:
   RFC7049: 
   I-D.ietf-rats-architecture: 
   I-D.ietf-rats-eat: 
-  I-D.ietf-suit-firmware-encryption:
   I-D.ietf-suit-manifest: 
   I-D.ietf-suit-trust-domains:
   I-D.ietf-suit-report:
@@ -93,6 +92,7 @@ normative:
       org: IANA
     target: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 informative:
+  I-D.ietf-suit-firmware-encryption:
   I-D.ietf-teep-architecture: 
   I-D.lundblade-rats-eat-media-type:
   RFC8610: 
@@ -1306,7 +1306,7 @@ confidentiality will be needed to protect sensitive fields from the TAM as
 discussed in Section 9.8 of {{I-D.ietf-teep-architecture}}.
 
 The ciphersuites defined above do not do encryption at the TEEP layer, but
-can do encryption of the SUIT payload as defined in {{I-D.ietf-suit-firmware-encryption}}.
+permit encryption of the SUIT payload (e.g., using {{I-D.ietf-suit-firmware-encryption}}).
 See {{security}} for more discussion of specific payloads.
 
 # Freshness Mechanisms {#freshness-mechanisms}
@@ -1387,7 +1387,7 @@ Trusted Component Binaries
 Personalization Data
 : A Trusted Component Signer or TAM can supply personalization data along with a Trusted Component.
   This data is also protected by a SUIT manifest.
-  Personalization data signed and encrypted (via {{I-D.ietf-suit-firmware-encryption}})
+  Personalization data signed and encrypted (e.g., via {{I-D.ietf-suit-firmware-encryption}})
   by a Trusted Component Signer other than
   the TAM is opaque to the TAM.
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -83,6 +83,7 @@ normative:
   RFC7049: 
   I-D.ietf-rats-architecture: 
   I-D.ietf-rats-eat: 
+  I-D.ietf-suit-firmware-encryption:
   I-D.ietf-suit-manifest: 
   I-D.ietf-suit-trust-domains:
   I-D.ietf-suit-report:
@@ -308,7 +309,7 @@ query-request = [
   type: TEEP-TYPE-query-request,
   options: {
     ? token => bstr .size (8..64),
-    ? supported-cipher-suites => [ + ciphersuite ],
+    ? supported-ciphersuites => [ + $ciphersuite ],
     ? supported-freshness-mechanisms => [ + freshness-mechanism ],
     ? challenge => bstr .size (8..512),
     ? versions => [ + version ],
@@ -365,8 +366,8 @@ data-item-requested
 
    Further values may be added in the future.
 
-supported-cipher-suites
-: The supported-cipher-suites parameter lists the ciphersuites supported by the TAM. If this parameter is not present, it is to be treated the same as if
+supported-ciphersuites
+: The supported-ciphersuites parameter lists the ciphersuites supported by the TAM. If this parameter is not present, it is to be treated the same as if
   it contained all ciphersuites defined in this document that are listed as "MUST". Details
   about the ciphersuite encoding can be found in {{ciphersuite}}.
 
@@ -410,7 +411,7 @@ query-response = [
   type: TEEP-TYPE-query-response,
   options: {
     ? token => bstr .size (8..64),
-    ? selected-cipher-suite => ciphersuite,
+    ? selected-ciphersuite => $ciphersuite,
     ? selected-version => version,
     ? attestation-payload-format => text,
     ? attestation-payload => bstr,
@@ -450,8 +451,8 @@ token
   if one was present, and MUST be absent if no token was present in the
   QueryRequest.
 
-selected-cipher-suite
-: The selected-cipher-suite parameter indicates the selected ciphersuite. If this
+selected-ciphersuite
+: The selected-ciphersuite parameter indicates the selected ciphersuite. If this
   parameter is not present, it is to be treated as if the TEEP Agent accepts
   any ciphersuites listed in the QueryRequest, so the TAM can select one.
   Details about the ciphersuite encoding can be found in {{ciphersuite}}.
@@ -940,7 +941,7 @@ teep-error = [
   options: {
      ? token => bstr .size (8..64),
      ? err-msg => text .size (1..128),
-     ? supported-cipher-suites => [ + ciphersuite ],
+     ? supported-ciphersuites => [ + $ciphersuite ],
      ? supported-freshness-mechanisms => [ + freshness-mechanism ],
      ? versions => [ + version ],
      ? suit-reports => [ + SUIT_Report ],
@@ -967,8 +968,8 @@ err-msg
 : The err-msg parameter is human-readable diagnostic text that MUST be encoded
   using UTF-8 {{RFC3629}} using Net-Unicode form {{RFC5198}} with max 128 bytes.
 
-supported-cipher-suites
-: The supported-cipher-suites parameter lists the ciphersuite(s) supported by the TEEP Agent.
+supported-ciphersuites
+: The supported-ciphersuites parameter lists the ciphersuite(s) supported by the TEEP Agent.
   Details about the ciphersuite encoding can be found in {{ciphersuite}}.
   This otherwise optional parameter MUST be returned if err-code is ERR_UNSUPPORTED_CIPHER_SUITES.
 
@@ -1123,10 +1124,10 @@ as a map key.
 This specification uses the following mapping:
 
 | Name                           | Label |
-| supported-cipher-suites        |     1 |
+| supported-ciphersuites         |     1 |
 | challenge                      |     2 |
 | versions                       |     3 |
-| selected-cipher-suite          |     5 |
+| selected-ciphersuite           |     5 |
 | selected-version               |     6 |
 | attestation-payload            |     7 |
 | tc-list                        |     8 |
@@ -1173,7 +1174,7 @@ was present.  If these requirements are not met, the TAM drops the message.  It 
 additional implementation specific actions such as logging the results.  If the requirements
 are met, processing continues as follows.
 
-If a QueryResponse message is received that contains that contains Evidence, the Evidence
+If a QueryResponse message is received that contains Evidence, the Evidence
 is passed to an attestation Verifier (see {{I-D.ietf-rats-architecture}})
 to determine whether the Agent is in a trustworthy state.  Once the TAM receives Attestation
 Results, processing continues as follows.
@@ -1257,51 +1258,42 @@ or Error message is generated only after completing the Update Procedure.
 # Ciphersuites {#ciphersuite}
 
 The TEEP protocol uses COSE for protection of TEEP messages.
-After a QueryResponse is received, the selected cryptographic algorithm is used in subsequent TEEP messages (Install, Success, and Error).
-To negotiate cryptographic mechanisms and algorithms, the TEEP protocol defines the following ciphersuite structure.
+After a QueryResponse is received, the selected ciphersuite is used in subsequent TEEP messages (Install, Success, and Error).
+To negotiate cryptographic mechanisms and algorithms, the TEEP protocol defines the following ciphersuite structure,
+which is used to specify an ordered set of operations (e.g., sign) done as part of composing a TEEP message.
+Although this specification only specifies the use of signing and relies on payload encryption to protect sensitive
+information, future extensions might specify support for encryption and/or MAC operations if needed.
 
 ~~~~
-ciphersuite = [
-    teep-cose-sign-algs / nil,
-    teep-cose-encrypt-algs / nil,
-    teep-cose-mac-algs / nil
-]
+$ciphersuite /= teep-ciphersuite-sign1-es256
+$ciphersuite /= teep-ciphersuite-sign1-eddsa
+
+; The following two ciphersuites have only a single operation each.
+; Other ciphersuites may be defined to have multiple operations.
+
+teep-ciphersuite-sign1-es256 = [ teep-operation-sign1-es256 ]
+teep-ciphersuite-sign1-eddsa = [ teep-operation-sign1-eddsa ]
+
+teep-operation-sign1-es256 = [ cose-sign1, cose-alg-es256 ]
+teep-operation-sign1-eddsa = [ cose-sign1, cose-alg-eddsa ]
+
+cose-sign1 = 18      ; CoAP Content-Format value
+
+cose-alg-es256 = -7  ; ECDSA w/ SHA-256
+cose-alg-eddsa = -8  ; EdDSA
 ~~~~
 
-The ciphersuite structure is used to present the combination of mechanisms and cryptographic algorithms.
-Each ciphersuite value corresponds with a COSE-type defined in Section 2 of {{RFC8152}}.
+Each operation in a given ciphersuite has two elements:
 
-~~~~
-supported-cipher-suites = [ + ciphersuite ]
-~~~~
+* a COSE-type defined in Section 2 of {{RFC8152}} that identifies the type of operation, and
+* a specific cryptographic algorithm as defined in the COSE Algorithms registry {{COSE.Algorithm}} to be used to perform that operation.
 
-Cryptographic algorithm values are defined in the COSE Algorithms registry {{COSE.Algorithm}}.
-A TAM MUST support both of the following ciphersuites.  A TEEP Agent MUST support at least
+A TAM MUST support both of the ciphersuites defined above.  A TEEP Agent MUST support at least
 one of the two but can choose which one.  For example, a TEEP Agent might
 choose a given ciphersuite if it has hardware support for it.
-
-~~~~
-teep-cose-sign-algs /= cose-alg-es256
-teep-cose-sign-algs /= cose-alg-eddsa
-~~~~
-
-A TAM or TEEP Agent MUST also support the following algorithms:
-
-~~~~
-teep-cose-encrypt-algs /= cose-alg-accm-16-64-128
-
-teep-cose-mac-algs /= cose-alg-hmac-256
-~~~~
-
-A TAM or TEEP Agent MAY also support one or more of the following algorithms:
-
-~~~~
-teep-cose-sign-algs /= cose-alg-ps256
-teep-cose-sign-algs /= cose-alg-ps384
-teep-cose-sign-algs /= cose-alg-ps512
-teep-cose-sign-algs /= cose-alg-rsa-oaep-256
-teep-cose-sign-algs /= cose-alg-rsa-oaep-512
-~~~~
+A TAM or TEEP Agent MAY also support any other algorithms in the COSE Algorithms
+registry in addition to the mandatory ones listed above.  It MAY also support use
+with COSE_Sign or other COSE types in additional ciphersuites.
 
 Any ciphersuites without confidentiality protection can only be added if the
 associated specification includes a discussion of security considerations and
@@ -1312,6 +1304,10 @@ provides confidentiality then additional encryption might not be needed in
 the manifest for some use cases. For most use cases, however, manifest
 confidentiality will be needed to protect sensitive fields from the TAM as
 discussed in Section 9.8 of {{I-D.ietf-teep-architecture}}.
+
+The ciphersuites defined above do not do encryption at the TEEP layer, but
+can do encryption of the SUIT payload as defined in {{I-D.ietf-suit-firmware-encryption}}.
+See {{security}} for more discussion of specific payloads.
 
 # Freshness Mechanisms {#freshness-mechanisms}
 
@@ -1385,12 +1381,14 @@ Trusted Component Binaries
   using the security mechanisms provided by the TEEP
   protocol.  To protect the Trusted Component binary, the SUIT manifest format is used and
   it offers a variety of security features, including digitial
-  signatures and symmetric encryption.
+  signatures and can support symmetric encryption if a SUIT mechanism such as {{I-D.ietf-suit-firmware-encryption}}
+  is used.
 
 Personalization Data
 : A Trusted Component Signer or TAM can supply personalization data along with a Trusted Component.
   This data is also protected by a SUIT manifest.
-  Personalization data signed and encrypted by a Trusted Component Signer other than
+  Personalization data signed and encrypted (via {{I-D.ietf-suit-firmware-encryption}})
+  by a Trusted Component Signer other than
   the TAM is opaque to the TAM.
 
 TEEP Broker
@@ -1574,7 +1572,9 @@ This section includes some examples with the following assumptions:
   / options: /
   {
     / token / 20 : h'A0A1A2A3A4A5A6A7A8A9AAABACADAEAF',
-    / supported-cipher-suites / 1 : [ [ -7, null, null ] ]  / use only ES256 /,
+    / supported-ciphersuites / 2 : [ [ [ 18, -7 ] ], / use only ES256 /
+                                     [ [ 18, -8 ] ]  / use only EdDSA /
+                                   ],
     / versions / 3 : [ 0 ]  / 0 is current TEEP Protocol /
   },
   / data-item-requested: / 3 / attestation | trusted-components /
@@ -1591,12 +1591,14 @@ This section includes some examples with the following assumptions:
       14            # unsigned(20) / token: /
       50            # bytes(16)
          A0A1A2A3A4A5A6A7A8A9AAABACADAEAF
-      01            # unsigned(1) / supported-cipher-suites: /
-      81            # array(1)
-         83         # array(3)
+      01            # unsigned(1) / supported-ciphersuites: /
+      82            # array(2)
+         83         # array(2)
+            12      # unsigned(18) / cose-sign1 /
             26      # negative(6) / -7 = cose-alg-es256 /
-            F6      # primitive(22) / null /
-            F6      # primitive(22) / null /
+         83         # array(2)
+            12      # unsigned(18) / cose-sign1 /
+            26      # negative(7) / -8 = cose-alg-eddsa /
       03            # unsigned(3) / versions: /
       81            # array(1) / [ 0 ] /
          00         # unsigned(0)
@@ -1643,7 +1645,7 @@ COSE is shown.
   / options: /
   {
     / token / 20 : h'A0A1A2A3A4A5A6A7A8A9AAABACADAEAF',
-    / selected-cipher-suite / 5 : [ -7, null, null ] / only use ES256 /,
+    / selected-ciphersuite / 5 : [ -7, null, null ] / only use ES256 /,
     / selected-version / 6 : 0,
     / attestation-payload / 7 : h'' / empty only for example purpose /,
     / tc-list / 8 : [
@@ -1668,11 +1670,10 @@ COSE is shown.
       14            # unsigned(20) / token: /
       50            # bytes(16)
          A0A1A2A3A4A5A6A7A8A9AAABACADAEAF
-      05            # unsigned(5) / selected-cipher-suite: /
-      83            # array(3)
+      05            # unsigned(5) / selected-ciphersuite: /
+      83            # array(2)
+         12         # unsigned(18) / cose-sign1 /
          26         # negative(6) / -7 = cose-alg-es256 /
-         F6         # primitive(22) / null /
-         F6         # primitive(22) / null /
       06            # unsigned(6) / selected-version: /
       00            # unsigned(0)
       07            # unsigned(7) / attestation-payload: /


### PR DESCRIPTION
* Change CDDL ciphersuite to $ciphersuite to be explicit that it supports extensibility
* Remove MAC and Encrypt algorithms and leave them to extensions
* Remove COSE_Sign_Tagged and leave it to extensions
* Fix contradiction between CDDL in body vs appendix (issue #208)
* Specify the order of operations within a ciphersuite is meaningful
* Make it clear that Agent only needs to support cose-sign1

Addresses #220

Signed-off-by: Dave Thaler <dthaler@microsoft.com>