### PR TITLE
Use newer kramdown-rfc2629 on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ pip3 install xml2rfc
 Installing required packages on Ubuntu
 ```
 apt-get update
-apt-get -y install ruby-kramdown-rfc2629 python3-pip git
+apt-get -y install python3-pip ruby git curl
 pip3 install xml2rfc
+gem install kramdown-rfc2629
 ```
 
 Installing cddl tool https://rubygems.org/gems/cddl


### PR DESCRIPTION
This is my found when I was trying cddl syntax check and Ken's PR.

There are two packages for kramdown-rfc2629 on ubuntu.
The ruby-kramdown-rfc2629 with apt and kramdown-rfc2629 with gem.
The ruby-kramdown-rfc2629 depends on old ruby 2.5 or older and do not work on ubuntu 20.04 or later which has ruby 2.7.

This PR fixes it by installing the kramdown-rfc2629 with gem which works on ruby 2.7 in ubuntu 20.04.

I was using ubuntu 18.04 when I wrote the initial instruction in the README.


