### PR TITLE
Updagin Akira`s email address

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -67,13 +67,13 @@ author:
  -
   ins: A. Tsukamoto
   name: Akira Tsukamoto
-  org: AIST
+  org: ''
   street: ''
   city: ''
   region: ''
   code: ''
   country: JP
-  email: akira.tsukamoto@aist.go.jp
+  email: akira.tsukamoto@gmail.com
 
 normative:
   RFC9052:


### PR DESCRIPTION
The email address of aist.go.jp is not reachable now.
Akira was working at AIST until the end of December 2022.