### PR TITLE
Use eat_nonce in EAT profile with challenge value from QueryResponse 

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -403,7 +403,7 @@ challenge
   When a challenge is 
   provided in the QueryRequest and an EAT is returned with a QueryResponse message
   then the challenge contained in this request MUST be used to generate the EAT,
-  such as by copying the challenge into the nonce claim found in the EAT if
+  such as by copying the challenge into the eat_nonce in the EAT profile {{eat}} if
   using the Nonce freshness mechanism.  For more details see {{freshness-mechanisms}}.
 
   If any format other than EAT is used, it is up to that


### PR DESCRIPTION
This is updating the sentence to clarify the value to be in the eat_nonce when the QueryResponse contains challenge value. 

The format of EAT profile using a eat-claim-set was defined at the IETF 115, this PR updates according to it. 