### PR TITLE
[0/5] Add TEEP and SUIT CDDL validation

### DIFF
--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -33,7 +33,7 @@ $(COSE_XML):
 	curl https://www.ietf.org/archive/id/draft-ietf-cose-msg-24.xml -o $@
 
 $(COSE_CDDL): $(COSE_XML)
-	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $^ | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' > $@
+	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $< | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' -e 's/\r$$//g' > $@
 
 .PHONY: cddl-validate-all
 cddl-validate-all: $(CONCATENATED_CDDL) $(MESSAGES)

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -3,14 +3,14 @@ MESSAGES := ../cbor/query_request.diag.bin ../cbor/query_response.diag.bin ../cb
 CONCATENATED_CDDL		:= check-draft-ietf-teep-protocol.cddl
 TEEP_PROTOCOL_CDDL		:= ../draft-ietf-teep-protocol.cddl
 SUIT_MANIFEST_CDDL		:= draft-ietf-suit-manifest.cddl
-SUIT_REPORT_MD			:= draft-ietf-suit-report.md
+SUIT_TRUST_COMANS_CDDL	:= draft-ietf-suit-trust-domains.cddl
 SUIT_REPORT_CDDL		:= draft-ietf-suit-report.cddl
 COSE_XML			:= rfc-8152-cose.xml
 COSE_CDDL			:= rfc-8152-cose.cddl
 WORKAROUND_DEPENDENCY		:= workaround_dependency.cddl
 
 CDDLS				:= $(TEEP_PROTOCOL_CDDL)
-CDDLS				+= $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_REPORT_CDDL)
+CDDLS				+= $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL)
 
 .PHONY: cat-cddl
 $(CONCATENATED_CDDL) cat-cddl: $(CDDLS)
@@ -21,6 +21,9 @@ $(MESSAGES):
 
 $(SUIT_MANIFEST_CDDL):
 	curl https://raw.githubusercontent.com/suit-wg/manifest-spec/master/draft-ietf-suit-manifest.cddl -o $@
+
+$(SUIT_TRUST_DOMAINS_CDDL):
+	curl https://raw.githubusercontent.com/suit-wg/suit-multiple-trust-domains/main/draft-ietf-suit-trust-domains.cddl -o $@
 
 $(SUIT_REPORT_CDDL):
 	curl https://raw.githubusercontent.com/suit-wg/suit-report/main/draft-ietf-suit-report.cddl -o $@

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -33,7 +33,7 @@ $(COSE_XML):
 	curl https://www.ietf.org/archive/id/draft-ietf-cose-msg-24.xml -o $@
 
 $(COSE_CDDL): $(COSE_XML)
-	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $< | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' -e 's/\r$$//g' > $@
+	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $< | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' > $@
 
 .PHONY: cddl-validate-all
 cddl-validate-all: $(CONCATENATED_CDDL) $(MESSAGES)

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -3,11 +3,10 @@ MESSAGES := ../cbor/query_request.diag.bin ../cbor/query_response.diag.bin ../cb
 CONCATENATED_CDDL		:= check-draft-ietf-teep-protocol.cddl
 TEEP_PROTOCOL_CDDL		:= ../draft-ietf-teep-protocol.cddl
 SUIT_MANIFEST_CDDL		:= draft-ietf-suit-manifest.cddl
-SUIT_TRUST_COMANS_CDDL	:= draft-ietf-suit-trust-domains.cddl
+SUIT_TRUST_DOMAINS_CDDL	:= draft-ietf-suit-trust-domains.cddl
 SUIT_REPORT_CDDL		:= draft-ietf-suit-report.cddl
 COSE_XML			:= rfc-8152-cose.xml
 COSE_CDDL			:= rfc-8152-cose.cddl
-WORKAROUND_DEPENDENCY		:= workaround_dependency.cddl
 
 CDDLS				:= $(TEEP_PROTOCOL_CDDL)
 CDDLS				+= $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL)
@@ -49,4 +48,4 @@ cddl-validate: cat-cddl $(MESSAGES) $(CONCATENATED_CDDL)
 
 .PHONY: clean
 clean:
-	$(RM) $(CONCATENATED_CDDL) $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_REPORT_CDDL) $(SUIT_REPORT_MD)
+	$(RM) $(CONCATENATED_CDDL) $(COSE_CDDL) $(COSE_XML) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL)


### PR DESCRIPTION
Add depending SUIT Manifest extension `draft-suit-trust-domains.cddl` to CDDL validation for dependency-resolution, uninstall and unlink functionalities.