### PR TITLE
[1/5] Add TEEP and SUIT CDDL validation

### DIFF
--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -1,9 +1,12 @@
 MESSAGES := ../cbor/query_request.diag.bin ../cbor/query_response.diag.bin ../cbor/update.diag.bin ../cbor/teep_success.diag.bin ../cbor/teep_error.diag.bin
 
 CONCATENATED_CDDL		:= check-draft-ietf-teep-protocol.cddl
+CONCATENATED_UNTAGGED_SUIT_CDDL	:= check-draft-ietf-suit-manifest.cddl
+CONCATENATED_CDDL		:= check-draft-ietf-teep-protocol.cddl
 TEEP_PROTOCOL_CDDL		:= ../draft-ietf-teep-protocol.cddl
+SUIT_ENVELOPE_SHIM_CDDL := suit-envelope-shim.cddl
 SUIT_MANIFEST_CDDL		:= draft-ietf-suit-manifest.cddl
-SUIT_TRUST_COMANS_CDDL	:= draft-ietf-suit-trust-domains.cddl
+SUIT_TRUST_DOMAINS_CDDL	:= draft-ietf-suit-trust-domains.cddl
 SUIT_REPORT_CDDL		:= draft-ietf-suit-report.cddl
 COSE_XML			:= rfc-8152-cose.xml
 COSE_CDDL			:= rfc-8152-cose.cddl
@@ -13,8 +16,13 @@ CDDLS				:= $(TEEP_PROTOCOL_CDDL)
 CDDLS				+= $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL)
 
 .PHONY: cat-cddl
-$(CONCATENATED_CDDL) cat-cddl: $(CDDLS)
-	cat $^ > $(CONCATENATED_CDDL)
+cat-cddl: $(CONCATENATED_CDDL)
+
+$(CONCATENATED_CDDL): $(TEEP_PROTOCOL_CDDL) $(CONCATENATED_UNTAGGED_SUIT_CDDL)
+	cat $^ > $@
+
+$(CONCATENATED_UNTAGGED_SUIT_CDDL): $(SUIT_ENVELOPE_SHIM_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL) $(COSE_CDDL)
+	cat $^ > $@
 
 $(MESSAGES):
 	make -C ../cbor
@@ -49,4 +57,4 @@ cddl-validate: cat-cddl $(MESSAGES) $(CONCATENATED_CDDL)
 
 .PHONY: clean
 clean:
-	$(RM) $(CONCATENATED_CDDL) $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_REPORT_CDDL) $(SUIT_REPORT_MD)
+	$(RM) $(CONCATENATED_CDDL) $(CONCATENATED_UNTAGGED_SUIT_CDDL) $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL) $(SUIT_REPORT_MD)

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -33,7 +33,7 @@ $(COSE_XML):
 	curl https://www.ietf.org/archive/id/draft-ietf-cose-msg-24.xml -o $@
 
 $(COSE_CDDL): $(COSE_XML)
-	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $^ | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' > $@
+	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $< | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' -e 's/\r$$//g' > $@
 
 .PHONY: cddl-validate-all
 cddl-validate-all: $(CONCATENATED_CDDL) $(MESSAGES)

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -3,14 +3,14 @@ MESSAGES := ../cbor/query_request.diag.bin ../cbor/query_response.diag.bin ../cb
 CONCATENATED_CDDL		:= check-draft-ietf-teep-protocol.cddl
 TEEP_PROTOCOL_CDDL		:= ../draft-ietf-teep-protocol.cddl
 SUIT_MANIFEST_CDDL		:= draft-ietf-suit-manifest.cddl
-SUIT_REPORT_MD			:= draft-ietf-suit-report.md
+SUIT_TRUST_COMANS_CDDL	:= draft-ietf-suit-trust-domains.cddl
 SUIT_REPORT_CDDL		:= draft-ietf-suit-report.cddl
 COSE_XML			:= rfc-8152-cose.xml
 COSE_CDDL			:= rfc-8152-cose.cddl
 WORKAROUND_DEPENDENCY		:= workaround_dependency.cddl
 
 CDDLS				:= $(TEEP_PROTOCOL_CDDL)
-CDDLS				+= $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_REPORT_CDDL)
+CDDLS				+= $(COSE_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL)
 
 .PHONY: cat-cddl
 $(CONCATENATED_CDDL) cat-cddl: $(CDDLS)
@@ -21,6 +21,9 @@ $(MESSAGES):
 
 $(SUIT_MANIFEST_CDDL):
 	curl https://raw.githubusercontent.com/suit-wg/manifest-spec/master/draft-ietf-suit-manifest.cddl -o $@
+
+$(SUIT_TRUST_DOMAINS_CDDL):
+	curl https://raw.githubusercontent.com/suit-wg/suit-multiple-trust-domains/main/draft-ietf-suit-trust-domains.cddl -o $@
 
 $(SUIT_REPORT_CDDL):
 	curl https://raw.githubusercontent.com/suit-wg/suit-report/main/draft-ietf-suit-report.cddl -o $@

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -1,4 +1,15 @@
-MESSAGES := ../cbor/query_request.diag.bin ../cbor/query_response.diag.bin ../cbor/update.diag.bin ../cbor/teep_success.diag.bin ../cbor/teep_error.diag.bin
+TEEP_MESSAGES := \
+		../cbor/query_request.diag.bin \
+		../cbor/query_response.diag.bin \
+		../cbor/update.diag.bin \
+		../cbor/teep_success.diag.bin \
+		../cbor/teep_error.diag.bin
+
+SUIT_MANIFESTS := \
+		../cbor/suit_uri.diag.bin \
+		../cbor/suit_integrated.diag.bin \
+		../cbor/suit_personalization.diag.bin \
+		../cbor/suit_unlink.diag.bin
 
 CONCATENATED_CDDL		:= check-draft-ietf-teep-protocol.cddl
 CONCATENATED_UNTAGGED_SUIT_CDDL	:= check-draft-ietf-suit-manifest.cddl
@@ -24,7 +35,7 @@ $(CONCATENATED_CDDL): $(TEEP_PROTOCOL_CDDL) $(CONCATENATED_UNTAGGED_SUIT_CDDL)
 $(CONCATENATED_UNTAGGED_SUIT_CDDL): $(SUIT_ENVELOPE_SHIM_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL) $(COSE_CDDL)
 	cat $^ > $@
 
-$(MESSAGES):
+$(TEEP_MESSAGES) $(SUIT_MANIFESTS):
 	make -C ../cbor
 
 $(SUIT_MANIFEST_CDDL):
@@ -44,15 +55,15 @@ $(COSE_CDDL): $(COSE_XML)
 	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $< | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' -e 's/\r$$//g' > $@
 
 .PHONY: cddl-validate-all
-cddl-validate-all: $(CONCATENATED_CDDL) $(MESSAGES)
-	$(foreach msg,$(MESSAGES),cddl $(CONCATENATED_CDDL) validate $(msg) || exit 1;)
+cddl-validate-all: $(CONCATENATED_CDDL) $(TEEP_MESSAGES)
+	$(foreach msg,$(TEEP_MESSAGES),cddl $(CONCATENATED_CDDL) validate $(msg) || exit 1;)
 
 .PHONY: cddl-gen
 cddl-gen: cat-cddl $(CONCATENATED_CDDL)
 	cddl $(CONCATENATED_CDDL) generate
 
 .PHONY: cddl-validate
-cddl-validate: cat-cddl $(MESSAGES) $(CONCATENATED_CDDL)
+cddl-validate: cat-cddl $(TEEP_MESSAGES) $(CONCATENATED_CDDL)
 	cddl $(CONCATENATED_CDDL) validate ../cbor/query_request.diag.bin
 
 .PHONY: clean

--- a/cddl/suit-envelope-shim.cddl
+++ b/cddl/suit-envelope-shim.cddl
@@ -1,0 +1,1 @@
+suit_envelope_shim = SUIT_Envelope


### PR DESCRIPTION
Create `check-draft-ietf-suit-manifest.cddl` to validate SUIT_Envelope (untagged).
Validates SUIT manifests with `check-draft-ietf-suit-manifest.cddl` and TEEP Protocol messages with `check-draft-ietf-teep-protocol.cddl` respectively.
Depends #299 , and [you can check the difference here](https://github.com/kentakayama/teep-protocol/compare/fix-cddl-v11-0-cat-cddl..fix-cddl-v11-1-Makefile).