### PR TITLE
[Maintenance] Syncronize cddls in body and appendix

### DIFF
--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -48,19 +48,14 @@ query-request = [
   data-item-requested: uint .bits data-item-requested
 ]
 
-;MANDATORY for TAM and TEEP Agent to support the following COSE
-;operations, and OPTIONAL to support additional ones such as
-;COSE_Sign_Tagged, COSE_Encrypt0_Tagged, etc.
+; cipher-suites
 
-cose-sign1 = 18      ; CoAP Content-Format value
+$cipher-suite /= teep-cipher-suite-sign1-eddsa
+$cipher-suite /= teep-cipher-suite-sign1-es256
 
-;MANDATORY for TAM to support the following, and OPTIONAL to implement
-;any additional algorithms from the IANA COSE Algorithms registry.
-
-cose-alg-eddsa = -8  ; EdDSA
-cose-alg-es256 = -7  ; ECDSA w/ SHA-256
-
-;MANDATORY for TAM to support the following cipher-suites, and OPTIONAL
+;The following two cipher suites have only a single operation each.
+;Other cipher suites may be defined to have multiple operations.
+;MANDATORY for TAM to support them, and OPTIONAL
 ;to support any additional ones that use COSE_Sign_Tagged, or other
 ;signing, encryption, or MAC algorithms.
 
@@ -70,18 +65,25 @@ teep-operation-sign1-es256 = [ cose-sign1, cose-alg-es256 ]
 teep-cipher-suite-sign1-eddsa = [ teep-operation-sign1-eddsa ]
 teep-cipher-suite-sign1-es256 = [ teep-operation-sign1-es256 ]
 
-$cipher-suite /= teep-cipher-suite-sign1-eddsa
-$cipher-suite /= teep-cipher-suite-sign1-es256
+;MANDATORY for TAM and TEEP Agent to support the following COSE
+;operations, and OPTIONAL to support additional ones such as
+;COSE_Sign_Tagged, COSE_Encrypt0_Tagged, etc.
+
+cose-sign1 = 18      ; CoAP Content-Format value
+
+;MANDATORY for TAM to support the following, and OPTIONAL to implement
+;any additional algorithms from the IANA COSE Algorithms registry.
+
+cose-alg-es256 = -7  ; ECDSA w/ SHA-256
+cose-alg-eddsa = -8  ; EdDSA
 
 ; freshness-mechanisms
 
 FRESHNESS_NONCE = 0
 FRESHNESS_TIMESTAMP = 1
-FRESHNESS_EPOCH_ID = 2
 
 $freshness-mechanism /= FRESHNESS_NONCE
 $freshness-mechanism /= FRESHNESS_TIMESTAMP
-$freshness-mechanism /= FRESHNESS_EPOCH_ID
 
 query-response = [
   type: TEEP-TYPE-query-response,

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -115,6 +115,8 @@ update = [
     ? token => bstr .size (8..64),
     ? unneeded-manifest-list => [ + SUIT_Component_Identifier ],
     ? manifest-list => [ + bstr .cbor SUIT_Envelope ],
+    ? attestation-payload-format => text,
+    ? attestation-payload => bstr,
     * $$update-extensions,
     * $$teep-option-extensions
   }

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1382,19 +1382,31 @@ Although this specification only specifies the use of signing and relies on payl
 information, future extensions might specify support for encryption and/or MAC operations if needed.
 
 ~~~~
-$cipher-suite /= teep-cipher-suite-sign1-es256
+; cipher-suites
+
 $cipher-suite /= teep-cipher-suite-sign1-eddsa
+$cipher-suite /= teep-cipher-suite-sign1-es256
 
-; The following two cipher suites have only a single operation each.
-; Other cipher suites may be defined to have multiple operations.
+;The following two cipher suites have only a single operation each.
+;Other cipher suites may be defined to have multiple operations.
+;MANDATORY for TAM to support them, and OPTIONAL
+;to support any additional ones that use COSE_Sign_Tagged, or other
+;signing, encryption, or MAC algorithms.
 
-teep-cipher-suite-sign1-es256 = [ teep-operation-sign1-es256 ]
-teep-cipher-suite-sign1-eddsa = [ teep-operation-sign1-eddsa ]
-
-teep-operation-sign1-es256 = [ cose-sign1, cose-alg-es256 ]
 teep-operation-sign1-eddsa = [ cose-sign1, cose-alg-eddsa ]
+teep-operation-sign1-es256 = [ cose-sign1, cose-alg-es256 ]
+
+teep-cipher-suite-sign1-eddsa = [ teep-operation-sign1-eddsa ]
+teep-cipher-suite-sign1-es256 = [ teep-operation-sign1-es256 ]
+
+;MANDATORY for TAM and TEEP Agent to support the following COSE
+;operations, and OPTIONAL to support additional ones such as
+;COSE_Sign_Tagged, COSE_Encrypt0_Tagged, etc.
 
 cose-sign1 = 18      ; CoAP Content-Format value
+
+;MANDATORY for TAM to support the following, and OPTIONAL to implement
+;any additional algorithms from the IANA COSE Algorithms registry.
 
 cose-alg-es256 = -7  ; ECDSA w/ SHA-256
 cose-alg-eddsa = -8  ; EdDSA
@@ -1453,6 +1465,8 @@ This document uses the following freshness mechanisms which may be added to in t
 future by TEEP extensions:
 
 ~~~~
+; freshness-mechanisms
+
 FRESHNESS_NONCE = 0
 FRESHNESS_TIMESTAMP = 1
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -447,7 +447,7 @@ query-response = [
 
 requested-tc-info = {
   component-id => SUIT_Component_Identifier,
-  ? tc-manifest-sequence-number => .within uint .size 8,
+  ? tc-manifest-sequence-number => uint .size 8,
   ? have-binary => bool
 }
 ~~~~


### PR DESCRIPTION
Synchronizing the cddls in the body and appendix for maintenance.
Relate to #208 but not solve it (still manually checking).
- reflect "deleting EPOCH_ID" ( 8e1b8033043d5418abc1ac330be57fde3b3ce4eb ) to Appendix
- reflect "adding attestation-payload" ( f238d50e62e888bf7018fc67439ecf987807b018 ) to Appendix
- merge "cipher-suite comments" ( 3610445b44b3c8cd96020d55d42e7a7c29af360d and de1d2dda4711cfdf311c212c40dd534d29b46b5e )

I'm also working on solving #208 [here](https://github.com/kentakayama/teep-protocol/compare/master...always-synchronize-cddl-and-article-part?expand=1).