### PR TITLE
Add SUIT_Parameters to system-property-claims

### DIFF
--- a/cbor/query_response.diag.txt
+++ b/cbor/query_response.diag.txt
@@ -9,10 +9,16 @@
     / attestation-payload / 7 : h'' / empty only for example purpose /,
     / tc-list / 8 : [
       {
-        / system-component-id / 0 : [ h'0102030405060708090A0B0C0D0E0F' ]
+        / system-component-id / 0 : [ h'0102030405060708090A0B0C0D0E0F' ],
+        / suit-parameter-image-digest / 3: << [
+          / suit-digest-algorithm-id / -16 / SHA256 /,
+          / suit-digest-bytes / h'a7fd6593eac32eb4be578278e6540c5c09cfd7d4d234973054833b2b93030609'
+            / SHA256 digest of tc binary /
+        ] >>
       },
       {
-        / system-component-id / 0 : [ h'1102030405060708090A0B0C0D0E0F' ]
+        / system-component-id / 0 : [ h'1102030405060708090A0B0C0D0E0F' ],
+        / suit-parameter-version / 28 : [1, 0, 0] / ver 1.0.0 /
       }
     ]
   }

--- a/cbor/query_response.hex.txt
+++ b/cbor/query_response.hex.txt
@@ -16,13 +16,21 @@
                     # ""
       08            # unsigned(8) / tc-list: /
       82            # array(2)
-         A1         # map(1)
+         A2         # map(2)
             00      # unsigned(0) / system-component-id: /
             81      # array(1)
                4F   # bytes(15)
                   0102030405060708090A0B0C0D0E0F
-         A1         # map(1)
+            03      # unsigned(3) / suit-parameter-image-digest: /
+            58 24   # bytes(36)
+               822F5820A7FD6593EAC32EB4BE578278E6540C5C09CFD7D4D234973054833B2B93030609
+         A2         # map(2)
             00      # unsigned(0) / system-component-id: /
             81      # array(1)
                4F   # bytes(15)
                   1102030405060708090A0B0C0D0E0F
+            18 1C   # unsigned(28) / suit-parameter-version: /
+            83      # array(3)
+               01   # unsigned(1)
+               00   # unsigned(0)
+               00   # unsigned(0)


### PR DESCRIPTION
Solves #291 .
The TAM can get much information about TCs in the device such as the digest and version of the TC.