### PR TITLE
Add support for EAT and SUIT Report encryption

### DIFF
--- a/cbor/query_request.diag.txt
+++ b/cbor/query_request.diag.txt
@@ -6,8 +6,8 @@
     / token / 20 : h'A0A1A2A3A4A5A6A7A8A9AAABACADAEAF',
     / versions / 3 : [ 0 ]  / 0 is current TEEP Protocol /
   },
-  / supported-cipher-suites: / [ [ [ 18, -7 ] ], / Sign1 using ES256 /
-                                 [ [ 18, -8 ] ]  / Sign1 using EdDSA /
-                                ],
+  / supported-teep-cipher-suites: / [ [ [ 18, -7 ] ], / Sign1 using ES256 /
+                                      [ [ 18, -8 ] ]  / Sign1 using EdDSA /
+                                    ],
   / data-item-requested: / 3 / attestation | trusted-components /
 ]

--- a/cbor/query_request.hex.txt
+++ b/cbor/query_request.hex.txt
@@ -1,4 +1,4 @@
-84                  # array(4)
+85                  # array(5)
    01               # unsigned(1) / TEEP-TYPE-query-request /
    A2               # map(2)
       14            # unsigned(20) / token: /
@@ -7,7 +7,7 @@
       03            # unsigned(3) / versions: /
       81            # array(1) / [ 0 ] /
          00         # unsigned(0)
-   82               # array(2) /* supported-cipher-suites /
+   82               # array(2) /* supported-teep-cipher-suites /
       81            # array(1)
          82         # array(2)
             12      # unsigned(18) / cose-sign1 /
@@ -16,4 +16,9 @@
          82         # array(2)
             12      # unsigned(18) / cose-sign1 /
             27      # negative(7) / -8 = cose-alg-eddsa /
+   81               # array(1) /* supported-eat-suit-cipher-suites /
+      81            # array(1)
+         82         # array(2)
+            10      # unsigned(16) / cose-encrypt0 /
+            0C      # unsigned(12) / 12 = cose-alg-aesccm /
    03               # unsigned(3) / attestation | trusted-components /

--- a/cbor/query_response.diag.txt
+++ b/cbor/query_response.diag.txt
@@ -4,7 +4,7 @@
   / options: /
   {
     / token / 20 : h'A0A1A2A3A4A5A6A7A8A9AAABACADAEAF',
-    / selected-cipher-suite / 5 : [ [ 18, -7 ] ] / only use ES256 /,
+    / selected-teep-cipher-suite / 5 : [ [ 18, -7 ] ] / only use ES256 /,
     / selected-version / 6 : 0,
     / attestation-payload / 7 : h'' / empty only for example purpose /,
     / tc-list / 8 : [

--- a/cbor/query_response.hex.txt
+++ b/cbor/query_response.hex.txt
@@ -4,7 +4,7 @@
       14            # unsigned(20) / token: /
       50            # bytes(16)
          A0A1A2A3A4A5A6A7A8A9AAABACADAEAF
-      05            # unsigned(5) / selected-cipher-suite: /
+      05            # unsigned(5) / selected-teep-cipher-suite: /
       81            # array(1)
          82         # array(2)
             12      # unsigned(18) / cose-sign1 /

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -44,14 +44,15 @@ query-request = [
     * $$query-request-extensions,
     * $$teep-option-extensions
   },
-  supported-cipher-suites: [ + $cipher-suite ],
+  supported-teep-cipher-suites: [ + $teep-cipher-suite ],
+  supported-eat-suit-cipher-suites: [ + $eat-suit-cipher-suite ],
   data-item-requested: uint .bits data-item-requested
 ]
 
-; cipher-suites
+; teep-cipher-suites
 
-$cipher-suite /= teep-cipher-suite-sign1-eddsa
-$cipher-suite /= teep-cipher-suite-sign1-es256
+$teep-cipher-suite /= teep-cipher-suite-sign1-eddsa
+$teep-cipher-suite /= teep-cipher-suite-sign1-es256
 
 ;The following two cipher suites have only a single operation each.
 ;Other cipher suites may be defined to have multiple operations.
@@ -77,6 +78,18 @@ cose-sign1 = 18      ; CoAP Content-Format value
 cose-alg-es256 = -7  ; ECDSA w/ SHA-256
 cose-alg-eddsa = -8  ; EdDSA
 
+; eat-suit-cipher-suites
+
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-aesccm
+
+eat-suit-cipher-suite-encrypt0-aesccm = [ teep-operation-encrypt0-aesccm ]
+
+eat-suit-operation-encrypt0-aesccm = [ cose-encrypt0, cose-alg-aesccm ]
+
+cose-encrypt0 = 16    ; CoAP Content-Format value
+
+cose-alg-aesccm = 12  ; AES-CCM-64-64-128
+
 ; freshness-mechanisms
 
 FRESHNESS_NONCE = 0
@@ -89,11 +102,11 @@ query-response = [
   type: TEEP-TYPE-query-response,
   options: {
     ? token => bstr .size (8..64),
-    ? selected-cipher-suite => $cipher-suite,
+    ? selected-teep-cipher-suite => $teep-cipher-suite,
     ? selected-version => version,
     ? attestation-payload-format => text,
     ? attestation-payload => bstr,
-    ? suit-reports => [ + SUIT_Report ],
+    ? suit-reports => [ + bstr ],
     ? tc-list => [ + system-property-claims ],
     ? requested-tc-list => [ + requested-tc-info ],
     ? unneeded-manifest-list => [ + SUIT_Component_Identifier ],
@@ -138,7 +151,7 @@ teep-error = [
   options: {
      ? token => bstr .size (8..64),
      ? err-msg => text .size (1..128),
-     ? supported-cipher-suites => [ + $cipher-suite ],
+     ? supported-teep-cipher-suites => [ + $teep-cipher-suite ],
      ? supported-freshness-mechanisms => [ + $freshness-mechanism ],
      ? versions => [ + version ],
      ? suit-reports => [ + SUIT_Report ],
@@ -160,10 +173,11 @@ ERR_TEMPORARY_ERROR = 10
 ERR_MANIFEST_PROCESSING_FAILED = 17
 
 ; labels of mapkey for teep message parameters, uint (0..23)
-supported-cipher-suites = 1
+supported-teep-cipher-suites = 1
 challenge = 2
 versions = 3
-selected-cipher-suite = 5
+supported-eat-suit-cipher-suites = 4
+selected-teep-cipher-suite = 5
 selected-version = 6
 attestation-payload = 7
 tc-list = 8

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -221,7 +221,7 @@ otherwise.
 
 # Detailed Messages Specification {#detailmsg}
 
-TEEP messages are protected by the COSE_Sign1 or COSE_Sign structure as described in {{ciphersuite}}.
+TEEP messages are protected by the COSE_Sign1 or COSE_Sign structure as described in {{teep-ciphersuite}}.
 The TEEP protocol messages are described in CDDL format {{RFC8610}} below.
 
 ~~~~
@@ -332,7 +332,8 @@ query-request = [
     * $$query-request-extensions,
     * $$teep-option-extensions
   },
-  supported-cipher-suites: [ + $cipher-suite ],
+  supported-teep-cipher-suites: [ + $teep-cipher-suite ],
+  supported-eat-suit-cipher-suites: [ + $eat-suit-cipher-suite ],
   data-item-requested: uint .bits data-item-requested
 ]
 ~~~~
@@ -364,9 +365,15 @@ token
   containing the token value and ignore any subsequent messages that have the same token
   value.
 
-supported-cipher-suites
-: The supported-cipher-suites parameter lists the cipher suites supported by the TAM. Details
-  about the cipher suite encoding can be found in {{ciphersuite}}.
+supported-teep-cipher-suites
+: The supported-teep-cipher-suites parameter lists the TEEP cipher suites
+  supported by the TAM. Details
+  about the cipher suite encoding can be found in {{teep-ciphersuite}}.
+
+supported-eat-suit-cipher-suites
+: The supported-eat-suit-cipher-suites parameter lists the EAT and SUIT cipher suites
+  supported by the TAM. Details
+  about the cipher suite encoding can be found in {{eat-suit-ciphersuite}}.
 
 data-item-requested
 : The data-item-requested parameter indicates what information the TAM requests from the TEEP
@@ -431,11 +438,11 @@ query-response = [
   type: TEEP-TYPE-query-response,
   options: {
     ? token => bstr .size (8..64),
-    ? selected-cipher-suite => $cipher-suite,
+    ? selected-teep-cipher-suite => $teep-cipher-suite,
     ? selected-version => version,
     ? attestation-payload-format => text,
     ? attestation-payload => bstr,
-    ? suit-reports => [ + SUIT_Report ],
+    ? suit-reports => [ + bstr ],
     ? tc-list => [ + system-property-claims ],
     ? requested-tc-list => [ + requested-tc-info ],
     ? unneeded-manifest-list => [ + SUIT_Component_Identifier ],
@@ -466,11 +473,11 @@ token
   if one was present, and MUST be absent if no token was present in the
   QueryRequest.
 
-selected-cipher-suite
-: The selected-cipher-suite parameter indicates the selected cipher suite. If this
+selected-teep-cipher-suite
+: The selected-teep-cipher-suite parameter indicates the selected TEEP cipher suite. If this
   parameter is not present, it is to be treated as if the TEEP Agent accepts
-  any cipher suites listed in the QueryRequest, so the TAM can select one.
-  Details about the cipher suite encoding can be found in {{ciphersuite}}.
+  any TEEP cipher suites listed in the QueryRequest, so the TAM can select one.
+  Details about the TEEP cipher suite encoding can be found in {{teep-ciphersuite}}.
 
 selected-version
 : The selected-version parameter indicates the TEEP protocol version selected by the
@@ -501,7 +508,8 @@ attestation-payload
 suit-reports
 : If present, the suit-reports parameter contains a set of "boot" (including
   starting an executable in an OS context) time SUIT Reports
-  as defined in Section 4 of {{I-D.ietf-suit-report}}.
+  as defined by SUIT_Report in Section 4 of {{I-D.ietf-suit-report}},
+  encoded using COSE as discussed in {{eat-suit-ciphersuite}}.
   If a token parameter was present in the QueryRequest
   message the QueryResponse message is in response to,
   the suit-report-nonce field MUST be present in the SUIT Report with a
@@ -1013,7 +1021,7 @@ teep-error = [
   options: {
      ? token => bstr .size (8..64),
      ? err-msg => text .size (1..128),
-     ? supported-cipher-suites => [ + $cipher-suite ],
+     ? supported-teep-cipher-suites => [ + $teep-cipher-suite ],
      ? supported-freshness-mechanisms => [ + $freshness-mechanism ],
      ? versions => [ + version ],
      ? suit-reports => [ + SUIT_Report ],
@@ -1040,9 +1048,9 @@ err-msg
 : The err-msg parameter is human-readable diagnostic text that MUST be encoded
   using UTF-8 {{RFC3629}} using Net-Unicode form {{RFC5198}} with max 128 bytes.
 
-supported-cipher-suites
-: The supported-cipher-suites parameter lists the cipher suite(s) supported by the TEEP Agent.
-  Details about the cipher suite encoding can be found in {{ciphersuite}}.
+supported-teep-cipher-suites
+: The supported-teep-cipher-suites parameter lists the TEEP cipher suite(s) supported by the TEEP Agent.
+  Details about the cipher suite encoding can be found in {{teep-ciphersuite}}.
   This otherwise optional parameter MUST be returned if err-code is ERR_UNSUPPORTED_CIPHER_SUITES.
 
 supported-freshness-mechanisms
@@ -1169,7 +1177,7 @@ of this document.)
 * CBOR String Encoding: Only definite-length strings are allowed.
 * CBOR Preferred Serialization: Encoders must use preferred serialization,
   and decoders need not accept non-preferred serialization.
-* COSE/JOSE Protection: See {{ciphersuite}}.
+* COSE/JOSE Protection: See {{eat-suit-ciphersuite}}.
 * Detached EAT Bundle Support: DEB use is permitted.
 * Verification Key Identification: COSE Key ID (kid) is used, where
   the key ID is the hash of a public key (where the public key may be
@@ -1205,27 +1213,28 @@ as a map key.
 
 This specification uses the following mapping:
 
-| Name                           | Label |
-| supported-cipher-suites        |     1 |
-| challenge                      |     2 |
-| versions                       |     3 |
-| selected-cipher-suite          |     5 |
-| selected-version               |     6 |
-| attestation-payload            |     7 |
-| tc-list                        |     8 |
-| ext-list                       |     9 |
-| manifest-list                  |    10 |
-| msg                            |    11 |
-| err-msg                        |    12 |
-| attestation-payload-format     |    13 |
-| requested-tc-list              |    14 |
-| unneeded-manifest-list         |    15 |
-| component-id                   |    16 |
-| tc-manifest-sequence-number    |    17 |
-| have-binary                    |    18 |
-| suit-reports                   |    19 |
-| token                          |    20 |
-| supported-freshness-mechanisms |    21 |
+| Name                             | Label |
+| supported-teep-cipher-suites     |     1 |
+| challenge                        |     2 |
+| versions                         |     3 |
+| supported-eat-suit-cipher-suites |     4 |
+| selected-teep-cipher-suite       |     5 |
+| selected-version                 |     6 |
+| attestation-payload              |     7 |
+| tc-list                          |     8 |
+| ext-list                         |     9 |
+| manifest-list                    |    10 |
+| msg                              |    11 |
+| err-msg                          |    12 |
+| attestation-payload-format       |    13 |
+| requested-tc-list                |    14 |
+| unneeded-manifest-list           |    15 |
+| component-id                     |    16 |
+| tc-manifest-sequence-number      |    17 |
+| have-binary                      |    18 |
+| suit-reports                     |    19 |
+| token                            |    20 |
+| supported-freshness-mechanisms   |    21 |
 
 # Behavior Specification
 
@@ -1375,6 +1384,8 @@ or Error message is generated only after completing the Update Procedure.
 
 # Cipher Suites {#ciphersuite}
 
+## TEEP Messages {#teep-ciphersuite}
+
 The TEEP protocol uses COSE for protection of TEEP messages in both directions.
 To negotiate cryptographic mechanisms and algorithms, the TEEP protocol defines the following cipher suite structure,
 which is used to specify an ordered set of operations (e.g., sign) done as part of composing a TEEP message.
@@ -1382,10 +1393,10 @@ Although this specification only specifies the use of signing and relies on payl
 information, future extensions might specify support for encryption and/or MAC operations if needed.
 
 ~~~~
-; cipher-suites
+; teep-cipher-suites
 
-$cipher-suite /= teep-cipher-suite-sign1-eddsa
-$cipher-suite /= teep-cipher-suite-sign1-es256
+$teep-cipher-suite /= teep-cipher-suite-sign1-eddsa
+$teep-cipher-suite /= teep-cipher-suite-sign1-es256
 
 ;The following two cipher suites have only a single operation each.
 ;Other cipher suites may be defined to have multiple operations.
@@ -1436,21 +1447,39 @@ discussed in Section 9.8 of {{I-D.ietf-teep-architecture}}.
 
 The cipher suites defined above do not do encryption at the TEEP layer, but
 permit encryption of the SUIT payload (e.g., using {{I-D.ietf-suit-firmware-encryption}}).
-See {{security}} for more discussion of specific payloads.
+See {{security}} and {{eat-suit-ciphersuites}} for more discussion of specific payloads.
 
 For the initial QueryRequest message, unless the TAM has more specific knowledge about the TEEP Agent
 (e.g., if the QueryRequest is sent in response to some underlying transport message that contains a hint),
 the message does not use COSE_Sign1 with one of the above cipher suites, but instead uses COSE_Sign with multiple signatures,
-one for each algorithm used in any of the cipher suites listed in the supported-cipher-suites
+one for each algorithm used in any of the cipher suites listed in the supported-teep-cipher-suites
 parameter of the QueryRequest, so that a TEEP Agent supporting any one of them can verify a signature.
 If the TAM does have specific knowledge about which cipher suite the TEEP Agent supports,
 it MAY instead use that cipher suite with the QueryRequest.
 
 For an Error message with code ERR_UNSUPPORTED_CIPHER_SUITES, the TEEP Agent MUST
-protect it with one of the cipher suites mandatory for the TAM.
+protect it with any of the cipher suites mandatory for the TAM.
 
-For all other messages between the TAM and TEEP Agent,
-the selected cipher suite MUST be used in both directions.
+For all other TEEP messages between the TAM and TEEP Agent,
+the selected TEEP cipher suite MUST be used in both directions.
+
+## EATs and SUIT Reports {#eat-suit-ciphersuite}
+
+TEEP uses COSE for confidentiality of EATs and SUIT Reports sent by a TEEP Agent.
+EATs and SUIT Reports sent by a TEEP Agent MUST support the cipher suite
+listed below, and MAY support other algorithms.
+
+~~~~
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-aesccm
+
+eat-suit-cipher-suite-encrypt0-aesccm = [ teep-operation-encrypt0-aesccm ]
+
+eat-suit-operation-encrypt0-aesccm = [ cose-encrypt0, cose-alg-aesccm ]
+
+cose-encrypt0 = 16    ; CoAP Content-Format value
+
+cose-alg-aesccm = 12  ; AES-CCM-64-64-128
+~~~~
 
 # Freshness Mechanisms {#freshness-mechanisms}
 
@@ -1585,6 +1614,9 @@ confidentiality is not provided by the TEEP protocol itself and
 the transport protocol under the TEEP protocol might be implemented
 outside of any TEE. If any mechanism other than EAT is used, it is
 up to that mechanism to specify how privacy is provided.
+
+Since SUIT Reports can also contain sensitive information, a TEEP Agent
+SHOULD also encrypt SUIT Reports as discussed in {{eat-suit-ciphersuite}}.
 
 In addition, in the usage scenario discussed in {{directtam}}, a device
 reveals its IP address to the Trusted Component Binary server.  This


### PR DESCRIPTION
This adds a mandatory field to the QueryRequest so is not backwards compatible.

Fixes #286