### PR TITLE
Add reference to draft-moran-suit-mti

### DIFF
--- a/cbor/query_request.hex.txt
+++ b/cbor/query_request.hex.txt
@@ -7,7 +7,7 @@
       03            # unsigned(3) / versions: /
       81            # array(1) / [ 0 ] /
          00         # unsigned(0)
-   82               # array(2) /* supported-teep-cipher-suites /
+   82               # array(2) / supported-teep-cipher-suites /
       81            # array(1)
          82         # array(2)
             12      # unsigned(18) / cose-sign1 /
@@ -16,9 +16,11 @@
          82         # array(2)
             12      # unsigned(18) / cose-sign1 /
             27      # negative(7) / -8 = cose-alg-eddsa /
-   81               # array(1) /* supported-eat-suit-cipher-suites /
-      81            # array(1)
-         82         # array(2)
-            10      # unsigned(16) / cose-encrypt0 /
-            0C      # unsigned(12) / 12 = cose-alg-aesccm /
+   82               # array(2) / supported-suit-cose-profiles /
+      82            # array(2) / suit-sha256-es256-hpke-a128gcm /
+         26         # negative(6) / -7 = cose-alg-es256 /
+         01         # unsigned(1) / 1 = A128GCM */
+      82            # array(2) / suit-sha256-eddsa-hpke-a128gcm /
+         27         # negative(7) / -8 = cose-alg-eddsa /
+         01         # unsigned(1) / 1 = A128GCM */
    03               # unsigned(3) / attestation | trusted-components /

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -19,6 +19,7 @@ SUIT_ENVELOPE_SHIM_CDDL := suit-envelope-shim.cddl
 SUIT_MANIFEST_CDDL		:= draft-ietf-suit-manifest.cddl
 SUIT_TRUST_DOMAINS_CDDL	:= draft-ietf-suit-trust-domains.cddl
 SUIT_REPORT_CDDL		:= draft-ietf-suit-report.cddl
+SUIT_MTI_CDDL			:= draft-moran-suit-mti-algorithms.cddl
 COSE_XML			:= rfc-8152-cose.xml
 COSE_CDDL			:= rfc-8152-cose.cddl
 
@@ -31,7 +32,7 @@ cat-cddl: $(CONCATENATED_CDDL)
 $(CONCATENATED_CDDL): $(TEEP_PROTOCOL_CDDL) $(CONCATENATED_UNTAGGED_SUIT_CDDL)
 	cat $^ > $@
 
-$(CONCATENATED_UNTAGGED_SUIT_CDDL): $(SUIT_ENVELOPE_SHIM_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL) $(COSE_CDDL)
+$(CONCATENATED_UNTAGGED_SUIT_CDDL): $(SUIT_ENVELOPE_SHIM_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL) $(SUIT_MTI_CDDL) $(COSE_CDDL)
 	cat $^ > $@
 
 $(TEEP_MESSAGES) $(SUIT_MANIFESTS):
@@ -46,6 +47,9 @@ $(SUIT_TRUST_DOMAINS_CDDL):
 $(SUIT_REPORT_CDDL):
 	curl https://raw.githubusercontent.com/suit-wg/suit-report/main/draft-ietf-suit-report.cddl -o $@
 	# cat $^ | sed -e 's/suit-record-properties     => SUIT_Parameters/suit-record-properties     => \{ \+ SUIT_Parameters \}/g' -e 's/^  \+ SUIT_Param/  * SUIT_Param/' > $@
+
+$(SUIT_MTI_CDDL):
+	curl https://raw.githubusercontent.com/bremoran/suit-mti/c9a5a3105e94e71f73841e7794995d20aaad821e/draft-moran-suit-mti-algorithms.cddl -o $@
 
 $(COSE_XML):
 	curl https://www.ietf.org/archive/id/draft-ietf-cose-msg-24.xml -o $@

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -80,15 +80,18 @@ cose-alg-eddsa = -8  ; EdDSA
 
 ; eat-suit-cipher-suites
 
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-aesccm
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-es256
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-eddsa
 
-eat-suit-cipher-suite-encrypt0-aesccm = [ teep-operation-encrypt0-aesccm ]
+eat-suit-cipher-suite-encrypt0-hpke-es256 = [ teep-operation-encrypt0-hpke-es256 ]
+eat-suit-cipher-suite-encrypt0-hpke-eddsa = [ teep-operation-encrypt0-hpke-eddsa ]
 
-eat-suit-operation-encrypt0-aesccm = [ cose-encrypt0, cose-alg-aesccm ]
+eat-suit-operation-encrypt0-hpke-es256 = [ cose-encrypt0, cose-alg-es256, cose-alg-a128gcm ]
+eat-suit-operation-encrypt0-hpke-eddsa = [ cose-encrypt0, cose-alg-eddsa, cose-alg-a128gcm ]
 
 cose-encrypt0 = 16    ; CoAP Content-Format value
 
-cose-alg-aesccm = 12  ; AES-CCM-64-64-128
+cose-alg-a128gcm = 1  ; AES-GCM mode w/ 128-bit key, 128-bit tag
 
 ; freshness-mechanisms
 

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -80,18 +80,15 @@ cose-alg-eddsa = -8  ; EdDSA
 
 ; eat-suit-cipher-suites
 
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-es256
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-eddsa
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-hpke-v1-base
 
-eat-suit-cipher-suite-encrypt0-hpke-es256 = [ teep-operation-encrypt0-hpke-es256 ]
-eat-suit-cipher-suite-encrypt0-hpke-eddsa = [ teep-operation-encrypt0-hpke-eddsa ]
+eat-suit-cipher-suite-hpke-v1-base = [ teep-operation-hpke-v1-base ]
 
-eat-suit-operation-encrypt0-hpke-es256 = [ cose-encrypt0, cose-alg-es256, cose-alg-a128gcm ]
-eat-suit-operation-encrypt0-hpke-eddsa = [ cose-encrypt0, cose-alg-eddsa, cose-alg-a128gcm ]
+eat-suit-operation-hpke-v1-base = [ cose-encrypt0, HPKE-v1-BASE ]
 
-cose-encrypt0 = 16    ; CoAP Content-Format value
+cose-encrypt0 = 16 ; CoAP Content-Format value
 
-cose-alg-a128gcm = 1  ; AES-GCM mode w/ 128-bit key, 128-bit tag
+HPKE-v1-BASE = -1  ; TBD
 
 ; freshness-mechanisms
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1533,27 +1533,25 @@ the selected TEEP cipher suite MUST be used in both directions.
 ## EATs and SUIT Reports {#eat-suit-ciphersuite}
 
 TEEP uses COSE for confidentiality of EATs and SUIT Reports sent by a TEEP Agent.
-EATs are typically signed by the attester, which is component different from the
-TEEP Agent. The TEEP Agent then obtains the signed EAT and encrypts it with the TAM
-as the recipient. The SUIT Report is most likely created by a SUIT processor, which
+The TEEP Agent obtains a signed EAT and then encrypts it with the TAM
+as the recipient. A SUIT Report is created by a SUIT processor, which
 is part of the TEEP Agent itself. The TEEP Agent is therefore in control of signing
 and encrypting the SUIT Report. Again, the TAM is the recipient of the encrypted
 content. For content-key distribution Hybrid Public Key Encryption (HPKE) is used
 in this specification. See COSE-HPKE {{I-D.ietf-cose-hpke}} for more details.
-This specification uses the COSE-HPKE variant for a single recipient, i.e. the TAM,
+This specification uses the COSE-HPKE variant for a single recipient, i.e., the TAM,
 which uses COSE_Encrypt0. This variant is described in Section 3.1.1 of {{I-D.ietf-cose-hpke}}.
 
 To perform encryption with HPKE the TEEP Agent needs to be in possession of the public
-key of the recipient, i.e. the TAM. See Section 5 of {{I-D.ietf-teep-architecture}}
+key of the recipient, i.e., the TAM. See Section 5 of {{I-D.ietf-teep-architecture}}
 for more discussion of TAM keys used by the TEEP Agent.
 
-This specification defines ciphersuites for confidentiality protection of EATs and
-SUIT Reports together with a digital signature algorithm. A TAM MUST support both
-of the cipher suites defined below, which are defined to be consistent with profiles
-listed in {{I-D.moran-suit-mti}}.  A TEEP Agent MUST support at least one of the
-two but can choose which one.  For example, a TEEP Agent might choose a given
-cipher suite if it has hardware support for it. A TAM or TEEP Agent MAY also support
-other algorithms in the COSE Algorithms registry in addition to the mandatory ones
+This specification defines cipher suites for confidentiality protection of EATs and
+SUIT Reports. The TEEP Agent and the TAM MUST support
+the cipher suite define below, which is defined to be consistent
+with {{I-D.moran-suit-mti}}.
+A TAM or TEEP Agent MAY also support
+other algorithms in the COSE Algorithms registry in addition to the mandatory one
 listed below.  It MAY also support use with COSE_Encrypt or other COSE types in
 additional cipher suites.
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -97,7 +97,7 @@ informative:
   I-D.ietf-teep-architecture: 
   I-D.ietf-rats-eat-media-type:
   I-D.ietf-rats-concise-ta-stores:
-  I-D.wallace-rats-concise-ta-stores:
+  I-D.moran-suit-mti:
   RFC8610: 
   RFC8915:
   RFC5934:
@@ -1533,7 +1533,8 @@ the selected TEEP cipher suite MUST be used in both directions.
 
 TEEP uses COSE for confidentiality of EATs and SUIT Reports sent by a TEEP Agent.
 EATs and SUIT Reports sent by a TEEP Agent MUST support the cipher suite
-listed below, and MAY support other algorithms.
+listed below (which is intended to be consistent with SUIT recommendations in
+{{I-D.moran-suit-mti}}), and MAY support other algorithms.
 
 ~~~~
 $eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-aesccm
@@ -1544,8 +1545,11 @@ eat-suit-operation-encrypt0-aesccm = [ cose-encrypt0, cose-alg-aesccm ]
 
 cose-encrypt0 = 16    ; CoAP Content-Format value
 
-cose-alg-aesccm = 12  ; AES-CCM-64-64-128
+cose-alg-aesccm = 12  ; AES-CCM-16-128-128
 ~~~~
+
+Encryption is done by the TEEP agent using the key of the destination TAM.
+See section 5 of {{I-D.ietf-teep-architecture}} for more discussion of TAM keys used by the TEEP agent.
 
 # Freshness Mechanisms {#freshness-mechanisms}
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1533,13 +1533,29 @@ the selected TEEP cipher suite MUST be used in both directions.
 ## EATs and SUIT Reports {#eat-suit-ciphersuite}
 
 TEEP uses COSE for confidentiality of EATs and SUIT Reports sent by a TEEP Agent.
-A TAM MUST support both of the cipher suites defined below, which are defined to
-be consistent with profiles listed in {{I-D.moran-suit-mti}}.  A TEEP Agent MUST
-support at least one of the two but can choose which one.  For example, a TEEP
-Agent might choose a given cipher suite if it has hardware support for it.
-A TAM or TEEP Agent MAY also support other algorithms in the COSE Algorithms
-registry in addition to the mandatory ones listed below.  It MAY also support use
-with COSE_Encrypt or other COSE types in additional cipher suites.
+EATs are typically signed by the attester, which is component different from the
+TEEP Agent. The TEEP Agent then obtains the signed EAT and encrypts it with the TAM
+as the recipient. The SUIT Report is most likely created by a SUIT processor, which
+is part of the TEEP Agent itself. The TEEP Agent is therefore in control of signing
+and encrypting the SUIT Report. Again, the TAM is the recipient of the encrypted
+content. For content-key distribution Hybrid Public Key Encryption (HPKE) is used
+in this specification. See COSE-HPKE {{I-D.ietf-cose-hpke}} for more details.
+This specification uses the COSE-HPKE variant for a single recipient, i.e. the TAM,
+which uses COSE_Encrypt0. This variant is described in Section 3.1.1 of {{I-D.ietf-cose-hpke}}.
+
+To perform encryption with HPKE the TEEP Agent needs to be in possession of the public
+key of the recipient, i.e. the TAM. See Section 5 of {{I-D.ietf-teep-architecture}}
+for more discussion of TAM keys used by the TEEP Agent.
+
+This specification defines ciphersuites for confidentiality protection of EATs and
+SUIT Reports together with a digital signature algorithm. A TAM MUST support both
+of the cipher suites defined below, which are defined to be consistent with profiles
+listed in {{I-D.moran-suit-mti}}.  A TEEP Agent MUST support at least one of the
+two but can choose which one.  For example, a TEEP Agent might choose a given
+cipher suite if it has hardware support for it. A TAM or TEEP Agent MAY also support
+other algorithms in the COSE Algorithms registry in addition to the mandatory ones
+listed below.  It MAY also support use with COSE_Encrypt or other COSE types in
+additional cipher suites.
 
 ~~~~
 $eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-es256
@@ -1556,8 +1572,7 @@ cose-encrypt0 = 16    ; CoAP Content-Format value
 cose-alg-a128gcm = 1  ; AES-GCM mode w/ 128-bit key, 128-bit tag
 ~~~~
 
-HPKE {{I-D.ietf-cose-hpke}} is done by the TEEP agent using the key of the destination TAM.
-See section 5 of {{I-D.ietf-teep-architecture}} for more discussion of TAM keys used by the TEEP agent.
+
 
 # Freshness Mechanisms {#freshness-mechanisms}
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1572,7 +1572,10 @@ cose-encrypt0 = 16    ; CoAP Content-Format value
 cose-alg-a128gcm = 1  ; AES-GCM mode w/ 128-bit key, 128-bit tag
 ~~~~
 
-
+Each "eat-suit-operation" above is defined as a tuple including:
+* a COSE-type defined in {{Section 2 of RFC9052}} that identifies the type of operation,
+* a specific Authentication Algorithm as defined in the COSE Algorithms registry {{COSE.Algorithm}}
+* a specific Encryption Algorithm as defined in the COSE Algorithms registry {{COSE.Algorithm}}
 
 # Freshness Mechanisms {#freshness-mechanisms}
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1533,14 +1533,14 @@ the selected TEEP cipher suite MUST be used in both directions.
 ## EATs and SUIT Reports {#eat-suit-ciphersuite}
 
 TEEP uses COSE for confidentiality of EATs and SUIT Reports sent by a TEEP Agent.
-The TEEP Agent obtains a signed EAT and then encrypts it with the TAM
+The TEEP Agent obtains a signed EAT and then SHOULD encrypt it using the TAM
 as the recipient. A SUIT Report is created by a SUIT processor, which
 is part of the TEEP Agent itself. The TEEP Agent is therefore in control of signing
-and encrypting the SUIT Report. Again, the TAM is the recipient of the encrypted
+the SUIT Report and SHOULD encrypt it. Again, the TAM is the recipient of the encrypted
 content. For content-key distribution Hybrid Public Key Encryption (HPKE) is used
 in this specification. See COSE-HPKE {{I-D.ietf-cose-hpke}} for more details.
 This specification uses the COSE-HPKE variant for a single recipient, i.e., the TAM,
-which uses COSE_Encrypt0. This variant is described in Section 3.1.1 of {{I-D.ietf-cose-hpke}}.
+which uses COSE_Encrypt0. This variant is described in {{Section 3.1.1 of I-D.ietf-cose-hpke}}.
 
 To perform encryption with HPKE the TEEP Agent needs to be in possession of the public
 key of the recipient, i.e., the TAM. See Section 5 of {{I-D.ietf-teep-architecture}}

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -337,7 +337,7 @@ query-request = [
     * $$teep-option-extensions
   },
   supported-teep-cipher-suites: [ + $teep-cipher-suite ],
-  supported-eat-suit-cipher-suites: [ + $eat-suit-cipher-suite ],
+  supported-suit-cose-profiles: [ + $suit-cose-profile ],
   data-item-requested: uint .bits data-item-requested
 ]
 ~~~~
@@ -374,8 +374,8 @@ supported-teep-cipher-suites
   supported by the TAM. Details
   about the cipher suite encoding can be found in {{teep-ciphersuite}}.
 
-supported-eat-suit-cipher-suites
-: The supported-eat-suit-cipher-suites parameter lists the EAT and SUIT cipher suites
+supported-suit-cose-profiles
+: The supported-suit-cose-profiles parameter lists the SUIT profiles
   supported by the TAM. Details
   about the cipher suite encoding can be found in {{eat-suit-ciphersuite}}.
 
@@ -1271,7 +1271,7 @@ This specification uses the following mapping:
 | supported-teep-cipher-suites     |     1 |
 | challenge                        |     2 |
 | versions                         |     3 |
-| supported-eat-suit-cipher-suites |     4 |
+| supported-suit-cose-profiles     |     4 |
 | selected-teep-cipher-suite       |     5 |
 | selected-version                 |     6 |
 | attestation-payload              |     7 |
@@ -1547,30 +1547,17 @@ key of the recipient, i.e., the TAM. See Section 5 of {{I-D.ietf-teep-architectu
 for more discussion of TAM keys used by the TEEP Agent.
 
 This specification defines cipher suites for confidentiality protection of EATs and
-SUIT Reports. The TEEP Agent and the TAM MUST support
-the cipher suite define below, which is defined to be consistent
-with {{I-D.moran-suit-mti}}.
-A TAM or TEEP Agent MAY also support
-other algorithms in the COSE Algorithms registry in addition to the mandatory one
-listed below.  It MAY also support use with COSE_Encrypt or other COSE types in
-additional cipher suites.
+SUIT Reports. The TAM MUST support each cipher suite defined below, based on definitions in
+{{I-D.moran-suit-mti}}.  A TEEP Agent MUST support at least one of the cipher
+suites below but can choose which one.  For example, a TEEP Agent might
+choose a given cipher suite if it has hardware support for it.
+A TAM or TEEP Agent MAY also support other algorithms in the COSE Algorithms registry.
+It MAY also support use with COSE_Encrypt or other COSE types in additional cipher suites.
 
 ~~~~
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-hpke-v1-base
-
-eat-suit-cipher-suite-hpke-v1-base = [ teep-operation-hpke-v1-base ]
-
-eat-suit-operation-hpke-v1-base = [ cose-encrypt0, HPKE-v1-BASE ]
-
-cose-encrypt0 = 16 ; CoAP Content-Format value
-
-HPKE-v1-BASE = -1  ; TBD
+$suit-cose-profile /= suit-sha256-es256-hpke-a128gcm
+$suit-cose-profile /= suit-sha256-eddsa-hpke-a128gcm
 ~~~~
-
-Each operation in a given cipher suite has two elements:
-
-* a COSE-type defined in {{Section 2 of RFC9052}} that identifies the type of operation,
-* a specific cryptographic algorithm as defined in the COSE Algorithms registry {{COSE.Algorithm}} to be used to perform that operation.
 
 # Freshness Mechanisms {#freshness-mechanisms}
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1558,24 +1558,21 @@ listed below.  It MAY also support use with COSE_Encrypt or other COSE types in
 additional cipher suites.
 
 ~~~~
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-es256
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-eddsa
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-hpke-v1-base
 
-eat-suit-cipher-suite-encrypt0-hpke-es256 = [ teep-operation-encrypt0-hpke-es256 ]
-eat-suit-cipher-suite-encrypt0-hpke-eddsa = [ teep-operation-encrypt0-hpke-eddsa ]
+eat-suit-cipher-suite-hpke-v1-base = [ teep-operation-hpke-v1-base ]
 
-eat-suit-operation-encrypt0-hpke-es256 = [ cose-encrypt0, cose-alg-es256, cose-alg-a128gcm ]
-eat-suit-operation-encrypt0-hpke-eddsa = [ cose-encrypt0, cose-alg-eddsa, cose-alg-a128gcm ]
+eat-suit-operation-hpke-v1-base = [ cose-encrypt0, HPKE-v1-BASE ]
 
-cose-encrypt0 = 16    ; CoAP Content-Format value
+cose-encrypt0 = 16 ; CoAP Content-Format value
 
-cose-alg-a128gcm = 1  ; AES-GCM mode w/ 128-bit key, 128-bit tag
+HPKE-v1-BASE = -1  ; TBD
 ~~~~
 
-Each "eat-suit-operation" above is defined as a tuple including:
+Each operation in a given cipher suite has two elements:
+
 * a COSE-type defined in {{Section 2 of RFC9052}} that identifies the type of operation,
-* a specific Authentication Algorithm as defined in the COSE Algorithms registry {{COSE.Algorithm}}
-* a specific Encryption Algorithm as defined in the COSE Algorithms registry {{COSE.Algorithm}}
+* a specific cryptographic algorithm as defined in the COSE Algorithms registry {{COSE.Algorithm}} to be used to perform that operation.
 
 # Freshness Mechanisms {#freshness-mechanisms}
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -87,6 +87,7 @@ normative:
   I-D.ietf-suit-trust-domains:
   I-D.ietf-suit-report:
   I-D.ietf-suit-firmware-encryption: 
+  I-D.ietf-cose-hpke:
   COSE.Algorithm:
     title: "COSE Algorithms"
     author:
@@ -1532,23 +1533,29 @@ the selected TEEP cipher suite MUST be used in both directions.
 ## EATs and SUIT Reports {#eat-suit-ciphersuite}
 
 TEEP uses COSE for confidentiality of EATs and SUIT Reports sent by a TEEP Agent.
-EATs and SUIT Reports sent by a TEEP Agent MUST support the cipher suite
-listed below (which is intended to be consistent with SUIT recommendations in
-{{I-D.moran-suit-mti}}), and MAY support other algorithms.
+A TAM MUST support both of the cipher suites defined below, which are defined to
+be consistent with profiles listed in {{I-D.moran-suit-mti}}.  A TEEP Agent MUST
+support at least one of the two but can choose which one.  For example, a TEEP
+Agent might choose a given cipher suite if it has hardware support for it.
+A TAM or TEEP Agent MAY also support other algorithms in the COSE Algorithms
+registry in addition to the mandatory ones listed below.  It MAY also support use
+with COSE_Encrypt or other COSE types in additional cipher suites.
 
 ~~~~
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-aesccm
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-es256
 
-eat-suit-cipher-suite-encrypt0-aesccm = [ teep-operation-encrypt0-aesccm ]
+eat-suit-cipher-suite-encrypt0-hpke-es256 = [ teep-operation-encrypt0-hpke-es256 ]
+eat-suit-cipher-suite-encrypt0-hpke-eddsa = [ teep-operation-encrypt0-hpke-eddsa ]
 
-eat-suit-operation-encrypt0-aesccm = [ cose-encrypt0, cose-alg-aesccm ]
+eat-suit-operation-encrypt0-hpke-es256 = [ cose-encrypt0, cose-alg-es256, cose-alg-a128gcm ]
+eat-suit-operation-encrypt0-hpke-eddsa = [ cose-encrypt0, cose-alg-eddsa, cose-alg-a128gcm ]
 
 cose-encrypt0 = 16    ; CoAP Content-Format value
 
-cose-alg-aesccm = 12  ; AES-CCM-16-128-128
+cose-alg-a128gcm = 1  ; AES-GCM mode w/ 128-bit key, 128-bit tag
 ~~~~
 
-Encryption is done by the TEEP agent using the key of the destination TAM.
+HPKE {{I-D.ietf-cose-hpke}} is done by the TEEP agent using the key of the destination TAM.
 See section 5 of {{I-D.ietf-teep-architecture}} for more discussion of TAM keys used by the TEEP agent.
 
 # Freshness Mechanisms {#freshness-mechanisms}

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -492,7 +492,7 @@ attestation-payload-format
 : The attestation-payload-format parameter indicates the IANA Media Type of the
   attestation-payload parameter, where media type parameters are permitted after
   the media type.  For protocol version 0, the absence of this parameter indicates that
-  the format is "application/eat+cwt; eat_profile=https://datatracker.ietf.org/doc/html/draft-ietf-teep-protocol-10" (see {{I-D.ietf-rats-eat-media-type}}
+  the format is "application/eat+cwt; eat_profile=https://datatracker.ietf.org/doc/html/draft-ietf-teep-protocol-12" (see {{I-D.ietf-rats-eat-media-type}}
   for further discussion).
   (RFC-editor: upon RFC publication, replace URI above with
   "https://www.rfc-editor.org/info/rfcXXXX" where XXXX is the RFC number
@@ -695,7 +695,7 @@ attestation-payload-format
 : The attestation-payload-format parameter indicates the IANA Media Type of the
   attestation-payload parameter, where media type parameters are permitted after
   the media type.  The absence of this parameter indicates that
-  the format is "application/eat+cwt; eat_profile=https://datatracker.ietf.org/doc/html/draft-ietf-teep-protocol-10" (see {{I-D.ietf-rats-eat-media-type}}
+  the format is "application/eat+cwt; eat_profile=https://datatracker.ietf.org/doc/html/draft-ietf-teep-protocol-12" (see {{I-D.ietf-rats-eat-media-type}}
   for further discussion).
   (RFC-editor: upon RFC publication, replace URI above with
   "https://www.rfc-editor.org/info/rfcXXXX" where XXXX is the RFC number
@@ -1182,7 +1182,7 @@ Entity Attestation Token profiles.  This section defines an EAT profile
 for use with TEEP.
 
 * profile-label: The profile-label for this specification is the URI
-<https://datatracker.ietf.org/doc/html/draft-ietf-teep-protocol-10>.
+<https://datatracker.ietf.org/doc/html/draft-ietf-teep-protocol-12>.
 (RFC-editor: upon RFC publication, replace string with
 "https://www.rfc-editor.org/info/rfcXXXX" where XXXX is the RFC number
 of this document.)

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1543,6 +1543,7 @@ with COSE_Encrypt or other COSE types in additional cipher suites.
 
 ~~~~
 $eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-es256
+$eat-suit-cipher-suite /= eat-suit-cipher-suite-encrypt0-hpke-eddsa
 
 eat-suit-cipher-suite-encrypt0-hpke-es256 = [ teep-operation-encrypt0-hpke-es256 ]
 eat-suit-cipher-suite-encrypt0-hpke-eddsa = [ teep-operation-encrypt0-hpke-eddsa ]


### PR DESCRIPTION
Add reference to draft-moran-suit-mti

And more closely align with the SUIT profiles therein.
Address more of #286

Still may not be quite right since HPKE apparently uses an ephemeral public key, whereas this PR currently implies using the non-ephemeral public key of the TAM.

Compare https://github.com/bremoran/suit-mti/pull/2