### PR TITLE
[hackathon] Extract cddl from md file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 FN := $(shell grep 'docname: draft-ietf-teep-protocol' draft-ietf-teep-protocol.md | awk '{print $$2}')
+CDDL_FILE := draft-ietf-teep-protocol.cddl
 
 .PHONY: all
-all: $(FN).cddl $(FN).txt $(FN).html
+all: $(CDDL_FILE) $(FN).txt $(FN).html
 
 .PHONY: cat-cddl
 cat-cddl:
@@ -23,13 +24,15 @@ validate-teep-cddl:
 	make -C cddl validate-teep-cddl
 
 CODE_PAT	:= ^\~\~\~\~
-%.cddl: %.md
+$(CDDL_FILE): $(CDDL_FILE:%.cddl=%.md)
 	> $@
 	sed -n '/${CODE_PAT} cddl-teep-message/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' > $@
 	echo >> $@
 	sed -n '/${CODE_PAT} cddl-query-request/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
 	echo >> $@
 	sed -n '/${CODE_PAT} cddl-cipher-suite/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-suit-cose-profile/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
 	echo >> $@
 	sed -n '/${CODE_PAT} cddl-freshness/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
 	echo >> $@
@@ -49,7 +52,7 @@ $(FN).html: $(FN).xml
 $(FN).txt: $(FN).xml
 	xml2rfc $(FN).xml
 
-$(FN).xml: draft-ietf-teep-protocol.md
+$(FN).xml: draft-ietf-teep-protocol.md $(CDDL_FILE)
 	kramdown-rfc2629 draft-ietf-teep-protocol.md > $(FN).xml
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ CODE_PAT	:= ^\~\~\~\~
 	echo >> $@
 	sed -n '/${CODE_PAT} cddl-query-request/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
 	echo >> $@
+	sed -n '/${CODE_PAT} cddl-cipher-suite/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-freshness/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
 	sed -n '/${CODE_PAT} cddl-query-response/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
 	echo >> $@
 	sed -n '/${CODE_PAT} cddl-update/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
@@ -37,10 +41,7 @@ CODE_PAT	:= ^\~\~\~\~
 	echo >> $@
 	sed -n '/${CODE_PAT} cddl-teep-error/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
 	echo >> $@
-	sed -n '/${CODE_PAT} cddl-cipher-suite/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
-	echo >> $@
-	sed -n '/${CODE_PAT} cddl-freshness/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
-	echo >> $@
+	sed -n '/${CODE_PAT} cddl-label/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
 
 $(FN).html: $(FN).xml
 	xml2rfc $(FN).xml --html

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-FN := $(shell grep 'docname: draft-ietf-teep-protocol' draft-ietf-teep-protocol.md | awk '{print $$2}')
-CDDL_FILE := draft-ietf-teep-protocol.cddl
+MD_FILE := draft-ietf-teep-protocol.md
+CDDL_FILE := $(MD_FILE:%.md=%.cddl)
+FN := $(shell grep 'docname: draft-ietf-teep-protocol' $(MD_FILE) | awk '{print $$2}')
 
 .PHONY: all
 all: $(CDDL_FILE) $(FN).txt $(FN).html
@@ -24,7 +25,7 @@ validate-teep-cddl:
 	make -C cddl validate-teep-cddl
 
 CODE_PAT	:= ^\~\~\~\~
-$(CDDL_FILE): $(CDDL_FILE:%.cddl=%.md)
+$(CDDL_FILE): $(MD_FILE)
 	> $@
 	sed -n '/${CODE_PAT} cddl-teep-message/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' > $@
 	echo >> $@
@@ -52,8 +53,8 @@ $(FN).html: $(FN).xml
 $(FN).txt: $(FN).xml
 	xml2rfc $(FN).xml
 
-$(FN).xml: draft-ietf-teep-protocol.md $(CDDL_FILE)
-	kramdown-rfc2629 draft-ietf-teep-protocol.md > $(FN).xml
+$(FN).xml: $(MD_FILE) $(CDDL_FILE)
+	kramdown-rfc2629 $(MD_FILE) > $(FN).xml
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FN := $(shell grep 'docname: draft-ietf-teep-protocol' draft-ietf-teep-protocol.md | awk '{print $$2}')
 
 .PHONY: all
-all: $(FN).txt $(FN).html
+all: $(FN).cddl $(FN).txt $(FN).html
 
 .PHONY: cat-cddl
 cat-cddl:
@@ -21,6 +21,26 @@ validate-cddl:
 .PHONY: validate-teep-cddl
 validate-teep-cddl:
 	make -C cddl validate-teep-cddl
+
+CODE_PAT	:= ^\~\~\~\~
+%.cddl: %.md
+	> $@
+	sed -n '/${CODE_PAT} cddl-teep-message/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' > $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-query-request/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-query-response/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-update/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-teep-success/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-teep-error/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-cipher-suite/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
+	sed -n '/${CODE_PAT} cddl-freshness/,/${CODE_PAT}/ p' $< | sed '/${CODE_PAT}.*/ d' >> $@
+	echo >> $@
 
 $(FN).html: $(FN).xml
 	xml2rfc $(FN).xml --html

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -23,17 +23,6 @@ TEEP-TYPE-update = 3
 TEEP-TYPE-teep-success = 5
 TEEP-TYPE-teep-error = 6
 
-version = uint .size 4
-ext-info = uint .size 4
-
-; data items as bitmaps
-data-item-requested = &(
-  attestation: 0,
-  trusted-components: 1,
-  extensions: 2,
-  suit-reports: 3,
-)
-
 query-request = [
   type: TEEP-TYPE-query-request,
   options: {
@@ -45,9 +34,20 @@ query-request = [
     * $$teep-option-extensions
   },
   supported-teep-cipher-suites: [ + $teep-cipher-suite ],
-  supported-eat-suit-cipher-suites: [ + $eat-suit-cipher-suite ],
+  supported-suit-cose-profiles: [ + $suit-cose-profile ],
   data-item-requested: uint .bits data-item-requested
 ]
+
+version = uint .size 4
+ext-info = uint .size 4
+
+; data items as bitmaps
+data-item-requested = &(
+  attestation: 0,
+  trusted-components: 1,
+  extensions: 2,
+  suit-reports: 3,
+)
 
 ; teep-cipher-suites
 
@@ -77,18 +77,6 @@ cose-sign1 = 18      ; CoAP Content-Format value
 
 cose-alg-es256 = -7  ; ECDSA w/ SHA-256
 cose-alg-eddsa = -8  ; EdDSA
-
-; eat-suit-cipher-suites
-
-$eat-suit-cipher-suite /= eat-suit-cipher-suite-hpke-v1-base
-
-eat-suit-cipher-suite-hpke-v1-base = [ teep-operation-hpke-v1-base ]
-
-eat-suit-operation-hpke-v1-base = [ cose-encrypt0, HPKE-v1-BASE ]
-
-cose-encrypt0 = 16 ; CoAP Content-Format value
-
-HPKE-v1-BASE = -1  ; TBD
 
 ; freshness-mechanisms
 
@@ -130,6 +118,8 @@ update = [
     ? manifest-list => [ + bstr .cbor SUIT_Envelope ],
     ? attestation-payload-format => text,
     ? attestation-payload => bstr,
+    ? err-code => uint .size 1,
+    ? err-msg => text .size (1..128),
     * $$update-extensions,
     * $$teep-option-extensions
   }
@@ -161,7 +151,7 @@ teep-error = [
   err-code: uint .size 1
 ]
 
-; The err-code parameter, uint .size 1 which takes a number from 0 to 23
+; The err-code parameter, uint (0..23)
 ERR_PERMANENT_ERROR = 1
 ERR_UNSUPPORTED_EXTENSION = 2
 ERR_UNSUPPORTED_FRESHNESS_MECHANISMS = 3
@@ -172,12 +162,11 @@ ERR_CERTIFICATE_EXPIRED = 9
 ERR_TEMPORARY_ERROR = 10
 ERR_MANIFEST_PROCESSING_FAILED = 17
 
-; labels of mapkey for teep message parameters in
-; uint .size 1 which takes a number from 0 to 23
+; labels of mapkey for teep message parameters, uint (0..23)
 supported-teep-cipher-suites = 1
 challenge = 2
 versions = 3
-supported-eat-suit-cipher-suites = 4
+supported-suit-cose-profiles = 4
 selected-teep-cipher-suite = 5
 selected-version = 6
 attestation-payload = 7

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -50,7 +50,6 @@ data-item-requested = &(
 )
 
 ; teep-cipher-suites
-
 $teep-cipher-suite /= teep-cipher-suite-sign1-eddsa
 $teep-cipher-suite /= teep-cipher-suite-sign1-es256
 
@@ -78,8 +77,11 @@ cose-sign1 = 18      ; CoAP Content-Format value
 cose-alg-es256 = -7  ; ECDSA w/ SHA-256
 cose-alg-eddsa = -8  ; EdDSA
 
-; freshness-mechanisms
+; suit-cose-profile
+$suit-cose-profile /= suit-sha256-es256-hpke-a128gcm
+$suit-cose-profile /= suit-sha256-eddsa-hpke-a128gcm
 
+; freshness-mechanisms
 FRESHNESS_NONCE = 0
 FRESHNESS_TIMESTAMP = 1
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1317,10 +1317,11 @@ This specification uses the following mapping:
 
 ~~~~ cddl-label
 ; labels of mapkey for teep message parameters, uint (0..23)
-supported-cipher-suites = 1
+supported-teep-cipher-suites = 1
 challenge = 2
 versions = 3
-selected-cipher-suite = 5
+supported-suit-cose-profiles = 4
+selected-teep-cipher-suite = 5
 selected-version = 6
 attestation-payload = 7
 tc-list = 8

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -1520,7 +1520,6 @@ information, future extensions might specify support for encryption and/or MAC o
 
 ~~~~ cddl-cipher-suite
 ; teep-cipher-suites
-
 $teep-cipher-suite /= teep-cipher-suite-sign1-eddsa
 $teep-cipher-suite /= teep-cipher-suite-sign1-es256
 
@@ -1613,7 +1612,8 @@ choose a given cipher suite if it has hardware support for it.
 A TAM or TEEP Agent MAY also support other algorithms in the COSE Algorithms registry.
 It MAY also support use with COSE_Encrypt or other COSE types in additional cipher suites.
 
-~~~~
+~~~~ cddl-suit-cose-profile
+; suit-cose-profile
 $suit-cose-profile /= suit-sha256-es256-hpke-a128gcm
 $suit-cose-profile /= suit-sha256-eddsa-hpke-a128gcm
 ~~~~
@@ -1632,7 +1632,6 @@ future by TEEP extensions:
 
 ~~~~ cddl-freshness
 ; freshness-mechanisms
-
 FRESHNESS_NONCE = 0
 FRESHNESS_TIMESTAMP = 1
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -335,6 +335,17 @@ query-request = [
   supported-cipher-suites: [ + $cipher-suite ],
   data-item-requested: uint .bits data-item-requested
 ]
+
+version = uint .size 4
+ext-info = uint .size 4
+
+; data items as bitmaps
+data-item-requested = &(
+  attestation: 0,
+  trusted-components: 1,
+  extensions: 2,
+  suit-reports: 3,
+)
 ~~~~
 
 The message has the following fields: 
@@ -1022,6 +1033,17 @@ teep-error = [
   },
   err-code: 0..23
 ]
+
+; The err-code parameter, uint (0..23)
+ERR_PERMANENT_ERROR = 1
+ERR_UNSUPPORTED_EXTENSION = 2
+ERR_UNSUPPORTED_FRESHNESS_MECHANISMS = 3
+ERR_UNSUPPORTED_MSG_VERSION = 4
+ERR_UNSUPPORTED_CIPHER_SUITES = 5
+ERR_BAD_CERTIFICATE = 6
+ERR_CERTIFICATE_EXPIRED = 9
+ERR_TEMPORARY_ERROR = 10
+ERR_MANIFEST_PROCESSING_FAILED = 17
 ~~~~
 
 The Error message has the following fields:
@@ -1226,6 +1248,30 @@ This specification uses the following mapping:
 | suit-reports                   |    19 |
 | token                          |    20 |
 | supported-freshness-mechanisms |    21 |
+
+~~~~ cddl-label
+; labels of mapkey for teep message parameters, uint (0..23)
+supported-cipher-suites = 1
+challenge = 2
+versions = 3
+selected-cipher-suite = 5
+selected-version = 6
+attestation-payload = 7
+tc-list = 8
+ext-list = 9
+manifest-list = 10
+msg = 11
+err-msg = 12
+attestation-payload-format = 13
+requested-tc-list = 14
+unneeded-manifest-list = 15
+component-id = 16
+tc-manifest-sequence-number = 17
+have-binary = 18
+suit-reports = 19
+token = 20
+supported-freshness-mechanisms = 21
+~~~~
 
 # Behavior Specification
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -224,7 +224,7 @@ otherwise.
 TEEP messages are protected by the COSE_Sign1 or COSE_Sign structure as described in {{ciphersuite}}.
 The TEEP protocol messages are described in CDDL format {{RFC8610}} below.
 
-~~~~
+~~~~ cddl-teep-message
 teep-message = $teep-message-type .within teep-message-framework
 
 teep-message-framework = [
@@ -321,7 +321,7 @@ Like other TEEP messages, the QueryRequest message is
 signed, and the relevant CDDL snippet is shown below. 
 The complete CDDL structure is shown in Appendix C.
 
-~~~~
+~~~~ cddl-query-request
 query-request = [
   type: TEEP-TYPE-query-request,
   options: {
@@ -426,7 +426,7 @@ Like other TEEP messages, the QueryResponse message is
 signed, and the relevant CDDL snippet is shown below. 
 The complete CDDL structure is shown in Appendix C.
 
-~~~~
+~~~~ cddl-query-response
 query-response = [
   type: TEEP-TYPE-query-response,
   options: {
@@ -633,7 +633,7 @@ Like other TEEP messages, the Update message is
 signed, and the relevant CDDL snippet is shown below. 
 The complete CDDL structure is shown in Appendix C.
 
-~~~~
+~~~~ cddl-update
 update = [
   type: TEEP-TYPE-update,
   options: {
@@ -958,7 +958,7 @@ Like other TEEP messages, the Success message is
 signed, and the relevant CDDL snippet is shown below. 
 The complete CDDL structure is shown in Appendix C.
 
-~~~~
+~~~~ cddl-teep-success
 teep-success = [
   type: TEEP-TYPE-teep-success,
   options: {
@@ -1007,7 +1007,7 @@ Like other TEEP messages, the Error message is
 signed, and the relevant CDDL snippet is shown below. 
 The complete CDDL structure is shown in Appendix C.
 
-~~~~
+~~~~ cddl-teep-error
 teep-error = [
   type: TEEP-TYPE-teep-error,
   options: {
@@ -1381,7 +1381,7 @@ which is used to specify an ordered set of operations (e.g., sign) done as part 
 Although this specification only specifies the use of signing and relies on payload encryption to protect sensitive
 information, future extensions might specify support for encryption and/or MAC operations if needed.
 
-~~~~
+~~~~ cddl-cipher-suite
 $cipher-suite /= teep-cipher-suite-sign1-es256
 $cipher-suite /= teep-cipher-suite-sign1-eddsa
 
@@ -1452,7 +1452,7 @@ an IANA registered freshness mechanism (see the IANA Considerations section of
 This document uses the following freshness mechanisms which may be added to in the
 future by TEEP extensions:
 
-~~~~
+~~~~ cddl-freshness
 FRESHNESS_NONCE = 0
 FRESHNESS_TIMESTAMP = 1
 


### PR DESCRIPTION
Solves #208 .

# Usage
`$ make ` extracts pieces of cddl from md file and concatenates them into cddl file.

# Note
Authors should modify not cddl file but md file, and commit both cddl and md files.
After you add new cddl piece in md file, you should also add the mark (like `cddl-query-request`) after the prefix `~~~~ cddl-foo` and insert sed command into Makefile around [here](https://github.com/kentakayama/teep-protocol/blob/extract-cddl/Makefile#L30).

# Changed
- modified md file
  - add `version`, `ext-info` and `data-item-requested`
  - add `ERR_*` cddl
  - add label cddl
  - add `cddl-*` marks before each cddl piece
- updated cddl file
  - now synchronized with cddl pieces in md file