### PR TITLE
[hackathon] limiting encoded uint size with not `.size` but immediate

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -459,7 +459,7 @@ query-response = [
 
 requested-tc-info = {
   component-id => SUIT_Component_Identifier,
-  ? tc-manifest-sequence-number => (0..18446744073709551615) / 1B FFFFFFFFFFFFFFFF /,
+  ? tc-manifest-sequence-number => uint .size 8,
   ? have-binary => bool
 }
 ~~~~

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -247,8 +247,8 @@ $teep-message-type /= update
 $teep-message-type /= teep-success
 $teep-message-type /= teep-error
 
-; message type numbers, uint .size 1 which takes a number from 0 to 23
-$teep-type = uint .size 1
+; message type numbers take a number from 0 to 23
+$teep-type = (0..23)
 TEEP-TYPE-query-request = 1
 TEEP-TYPE-query-response = 2
 TEEP-TYPE-update = 3
@@ -459,7 +459,7 @@ query-response = [
 
 requested-tc-info = {
   component-id => SUIT_Component_Identifier,
-  ? tc-manifest-sequence-number => uint .size 8,
+  ? tc-manifest-sequence-number => (0..18446744073709551615) / 1B FFFFFFFFFFFFFFFF /,
   ? have-binary => bool
 }
 ~~~~
@@ -655,7 +655,7 @@ update = [
     ? manifest-list => [ + bstr .cbor SUIT_Envelope ],
     ? attestation-payload-format => text,
     ? attestation-payload => bstr,
-    ? err-code => uint .size 1,
+    ? err-code => (0..23),
     ? err-msg => text .size (1..128),
     * $$update-extensions,
     * $$teep-option-extensions
@@ -1044,7 +1044,7 @@ teep-error = [
      * $$teep-error-extensions,
      * $$teep-option-extensions
   },
-  err-code: uint .size 1
+  err-code: (0..23)
 ]
 ~~~~
 

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -247,7 +247,7 @@ $teep-message-type /= update
 $teep-message-type /= teep-success
 $teep-message-type /= teep-error
 
-; message type numbers take a number from 0 to 23
+; message type numbers, in one byte which could take a number from 0 to 23
 $teep-type = (0..23)
 TEEP-TYPE-query-request = 1
 TEEP-TYPE-query-response = 2


### PR DESCRIPTION
Fixes `uint .size 1` to `(0..23)`.

# Why
[RFC 8610](https://datatracker.ietf.org/doc/html/rfc8610#section-3.8.1) says below.
> The control is defined for text and byte strings, where it directly controls the number of bytes in the string.  It is also defined for unsigned integers (see below).
> ...
> When applied to an unsigned integer, the ".size" control restricts the range of that integer by giving a maximum number of bytes that should be needed in a computer representation of that unsigned integer.  In other words, "uint .size N" is equivalent to "0...BYTES_N", where BYTES_N == 256**N.

Our purpose to use `uint .size 1` is to limit the **encoded cbor binary length**, but the `.size` operator limits the represented value.
They are slightly different, for example, CDDL `uint .size 1` allows the value `24` and CDDL `(0..23)` does not.
`uint .size 8` limits encoded size between 1 and 9 bytes, so does not matter.

These tables might help you.

| cddl validateion | our purpose | cddl text | value | encoded |
|--|--|--|--|--|
| :heavy_check_mark: valid | :heavy_check_mark: yes | uint .size 1 | 0 | 00 (1 byte) |
| :heavy_check_mark: valid | :heavy_check_mark: yes | uint .size 1 | 23 | 17 (1 byte) |
| :heavy_check_mark: valid | :x: no | uint .size 1 | 24 | 18 18 (2 bytes) |
| :heavy_check_mark: valid | :x: no | uint .size 1 | 255 | 18 FF (2 bytes) |
| :x: invalid | :heavy_check_mark: yes | uint .size 1 | 256 | 19 01 00 (3 bytes) |
| :heavy_check_mark: valid | :heavy_check_mark: yes | uint .size 2 | 255 | 18 FF (2 bytes) |
| :heavy_check_mark: valid | :heavy_check_mark: yes | uint .size 2 | 256 | 19 01 00 (3 bytes) |

| cddl validateion | our purpose | cddl text | value | encoded |
|--|--|--|--|--|
| :heavy_check_mark: valid | :heavy_check_mark: yes | 0..23 | 0 | 00 (1 byte) |
| :heavy_check_mark: valid | :heavy_check_mark: yes | 0..23 | 23 | 17 (1 byte) |
| :x: invalid | :heavy_check_mark: yes | 0..23 | 24 | 18 18 (2 bytes) |
| :x: invalid | :heavy_check_mark: yes | 0..23 | 255 | 18 FF (2 bytes) |
| :x: invalid | :heavy_check_mark: yes | 0..23 | 256 | 19 01 00 (3 bytes) |
| :heavy_check_mark: valid | :heavy_check_mark: yes | 0..255 | 255 | 18 FF (2 bytes) |
| :x: invalid | :heavy_check_mark: yes | 0..255 | 256 | 19 01 00 (3 bytes) |

