### PR TITLE
Fix v13 cbor and cddl

### DIFF
--- a/cbor/Makefile
+++ b/cbor/Makefile
@@ -9,8 +9,7 @@ DIAG_TEEP_MESSAGES := \
 DIAG_SUIT_MANIFESTS := \
 		suit_uri.diag.txt \
 		suit_integrated.diag.txt \
-		suit_personalization.diag.txt \
-		suit_unlink.diag.txt
+		suit_personalization.diag.txt
 
 DIAG_FILES := $(DIAG_TEEP_MESSAGES) $(DIAG_SUIT_MANIFESTS)
 HEX_FILES := $(DIAG_TEEP_MESSAGES:.diag.txt=.hex.txt) $(DIAG_SUIT_MANIFESTS:.diag.txt=.hex.txt)

--- a/cbor/query_request.diag.txt
+++ b/cbor/query_request.diag.txt
@@ -6,8 +6,11 @@
     / token / 20 : h'A0A1A2A3A4A5A6A7A8A9AAABACADAEAF',
     / versions / 3 : [ 0 ]  / 0 is current TEEP Protocol /
   },
-  / supported-teep-cipher-suites: / [ [ [ 18, -7 ] ], / Sign1 using ES256 /
-                                      [ [ 18, -8 ] ]  / Sign1 using EdDSA /
+  / supported-teep-cipher-suites: / [ [ [ 18, -7 ] ] / Sign1 using ES256 /,
+                                      [ [ 18, -8 ] ] / Sign1 using EdDSA /
+                                    ],
+  / supported-suit-cose-profiles: / [ [ -7, 1 ] / ES256+ECDH+A128GCM /,
+                                      [ -8, 1 ] / EdDSA+ECDH+A128GCM /
                                     ],
   / data-item-requested: / 3 / attestation | trusted-components /
 ]

--- a/cbor/query_request.hex.txt
+++ b/cbor/query_request.hex.txt
@@ -19,8 +19,8 @@
    82               # array(2) / supported-suit-cose-profiles /
       82            # array(2) / suit-sha256-es256-ecdh-a128gcm /
          26         # negative(6) / -7 = cose-alg-es256 /
-         01         # unsigned(1) / 1 = A128GCM */
+         01         # unsigned(1) / 1 = A128GCM /
       82            # array(2) / suit-sha256-eddsa-ecdh-a128gcm /
          27         # negative(7) / -8 = cose-alg-eddsa /
-         01         # unsigned(1) / 1 = A128GCM */
+         01         # unsigned(1) / 1 = A128GCM /
    03               # unsigned(3) / attestation | trusted-components /

--- a/cbor/query_request.hex.txt
+++ b/cbor/query_request.hex.txt
@@ -17,10 +17,10 @@
             12      # unsigned(18) / cose-sign1 /
             27      # negative(7) / -8 = cose-alg-eddsa /
    82               # array(2) / supported-suit-cose-profiles /
-      82            # array(2) / suit-sha256-es256-hpke-a128gcm /
+      82            # array(2) / suit-sha256-es256-ecdh-a128gcm /
          26         # negative(6) / -7 = cose-alg-es256 /
          01         # unsigned(1) / 1 = A128GCM */
-      82            # array(2) / suit-sha256-eddsa-hpke-a128gcm /
+      82            # array(2) / suit-sha256-eddsa-ecdh-a128gcm /
          27         # negative(7) / -8 = cose-alg-eddsa /
          01         # unsigned(1) / 1 = A128GCM */
    03               # unsigned(3) / attestation | trusted-components /

--- a/cbor/suit_personalization.diag.txt
+++ b/cbor/suit_personalization.diag.txt
@@ -38,7 +38,7 @@
         / directive-set-component-index / 12, 0,
         / directive-override-parameters / 20, {
           / parameter-vendor-identifier / 1: h'C0DDD5F15243566087DB4F5B0AA26C2F',
-          / parameter-class-identifier / 2: h'DB42F7093D8C55BAA8C5265FC5820F4E',
+          / parameter-class-identifier / 2: h'DB42F7093D8C55BAA8C5265FC5820F4E'
         },
         / condition-vendor-identifier / 1, 15,
         / condition-class-identifier / 2, 15

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -17,6 +17,7 @@ TEEP_PROTOCOL_CDDL		:= ../draft-ietf-teep-protocol.cddl
 SUIT_ENVELOPE_SHIM_CDDL := suit-envelope-shim.cddl
 SUIT_MANIFEST_CDDL		:= draft-ietf-suit-manifest.cddl
 SUIT_TRUST_DOMAINS_CDDL	:= draft-ietf-suit-trust-domains.cddl
+SUIT_ENCRYPTED_PAYLOADS_CDDL	:= draft-ietf-suit-firmware-encryption.cddl
 SUIT_REPORT_CDDL		:= draft-ietf-suit-report.cddl
 SUIT_MTI_CDDL			:= draft-moran-suit-mti-algorithms.cddl
 COSE_XML			:= rfc-8152-cose.xml
@@ -31,7 +32,7 @@ cat-cddl: $(CONCATENATED_CDDL)
 $(CONCATENATED_CDDL): $(TEEP_PROTOCOL_CDDL) $(CONCATENATED_UNTAGGED_SUIT_CDDL)
 	cat $^ > $@
 
-$(CONCATENATED_UNTAGGED_SUIT_CDDL): $(SUIT_ENVELOPE_SHIM_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL) $(SUIT_MTI_CDDL) $(COSE_CDDL)
+$(CONCATENATED_UNTAGGED_SUIT_CDDL): $(SUIT_ENVELOPE_SHIM_CDDL) $(SUIT_MANIFEST_CDDL) $(SUIT_TRUST_DOMAINS_CDDL) $(SUIT_REPORT_CDDL) $(SUIT_MTI_CDDL) $(SUIT_ENCRYPTED_PAYLOADS_CDDL) $(COSE_CDDL)
 	cat $^ > $@
 
 $(TEEP_MESSAGES) $(SUIT_MANIFESTS):

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -8,8 +8,7 @@ TEEP_MESSAGES := \
 SUIT_MANIFESTS := \
 		../cbor/suit_uri.diag.bin \
 		../cbor/suit_integrated.diag.bin \
-		../cbor/suit_personalization.diag.bin \
-		../cbor/suit_unlink.diag.bin
+		../cbor/suit_personalization.diag.bin
 
 CONCATENATED_CDDL		:= check-draft-ietf-teep-protocol.cddl
 CONCATENATED_UNTAGGED_SUIT_CDDL	:= check-draft-ietf-suit-manifest.cddl

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -46,10 +46,9 @@ $(SUIT_TRUST_DOMAINS_CDDL):
 
 $(SUIT_REPORT_CDDL):
 	curl https://raw.githubusercontent.com/suit-wg/suit-report/main/draft-ietf-suit-report.cddl -o $@
-	# cat $^ | sed -e 's/suit-record-properties     => SUIT_Parameters/suit-record-properties     => \{ \+ SUIT_Parameters \}/g' -e 's/^  \+ SUIT_Param/  * SUIT_Param/' > $@
 
 $(SUIT_MTI_CDDL):
-	curl https://raw.githubusercontent.com/bremoran/suit-mti/c9a5a3105e94e71f73841e7794995d20aaad821e/draft-moran-suit-mti-algorithms.cddl -o $@
+	curl https://raw.githubusercontent.com/bremoran/suit-mti/main/draft-moran-suit-mti-algorithms.cddl -o $@
 
 $(COSE_XML):
 	curl https://www.ietf.org/archive/id/draft-ietf-cose-msg-24.xml -o $@

--- a/cddl/draft-ietf-suit-firmware-encryption.cddl
+++ b/cddl/draft-ietf-suit-firmware-encryption.cddl
@@ -1,0 +1,5 @@
+suit-parameter-encryption-info = 19
+$$SUIT_Parameters //= (
+    suit-parameter-encryption-info => COSE_Encryption_Info)
+
+COSE_Encryption_Info = bstr .cbor COSE_Encrypt_Tagged

--- a/draft-ietf-teep-protocol.cddl
+++ b/draft-ietf-teep-protocol.cddl
@@ -192,3 +192,4 @@ have-binary = 18
 suit-reports = 19
 token = 20
 supported-freshness-mechanisms = 21
+err-code = 22


### PR DESCRIPTION
Fixing error in `make validate-cbor` and `make validate-cddl` (`make validate` in short).

## Fix
- rm: suit_unlink manifest from `cbor/Makefile` and `cddl/Makefile` (Not necessary anymore.)
- nit: `suit_personalization.diag.txt`
- nit: `query_request.hex.txt`

## Update (Please check carefully)
- fix: the URL of SUIT MTI CDDL in `cddl/Makefile` (Because previous CDDL causes some error.)
- add: options label for `err-code` introduced in 076f3d3
- add: SUIT Encrypted Payload CDDL for suit_personalization (Manually added only necessary part to `cddl/draft-ietf-suit-firmware-encryption.cddl`)

## How to check
Still waiting [a PR to be merged](https://github.com/suit-wg/suit-multiple-trust-domains/pull/10).
Or you can run CDDL validation with manually fix the generated CDDL files `cddl/check-draft-ietf-suit-manifest.cddl` and `cddl/check-draft-ietf-teep-protocol.cddl` like below.
``` diff
     * $$SUIT_Dependency_Extensions
 }
 
- SUIT_Condition // (
+ SUIT_Condition //= (
     suit-condition-dependency-integrity, SUIT_Rep_Policy)
 SUIT_Condition //= (
     suit-condition-is-dependency, SUIT_Rep_Policy)
```