### PR TITLE
Update QueryResponse example to avoid CDDL validation error

### DIFF
--- a/cbor/query_response.diag.txt
+++ b/cbor/query_response.diag.txt
@@ -15,10 +15,6 @@
           / suit-digest-bytes / h'a7fd6593eac32eb4be578278e6540c5c09cfd7d4d234973054833b2b93030609'
             / SHA256 digest of tc binary /
         ] >>
-      },
-      {
-        / system-component-id / 0 : [ h'1102030405060708090A0B0C0D0E0F' ],
-        / suit-parameter-version / 28 : [1, 0, 0] / ver 1.0.0 /
       }
     ]
   }

--- a/cbor/query_response.hex.txt
+++ b/cbor/query_response.hex.txt
@@ -15,7 +15,7 @@
       40            # bytes(0)
                     # ""
       08            # unsigned(8) / tc-list: /
-      82            # array(2)
+      81            # array(1)
          A2         # map(2)
             00      # unsigned(0) / system-component-id: /
             81      # array(1)
@@ -24,13 +24,3 @@
             03      # unsigned(3) / suit-parameter-image-digest: /
             58 24   # bytes(36)
                822F5820A7FD6593EAC32EB4BE578278E6540C5C09CFD7D4D234973054833B2B93030609
-         A2         # map(2)
-            00      # unsigned(0) / system-component-id: /
-            81      # array(1)
-               4F   # bytes(15)
-                  1102030405060708090A0B0C0D0E0F
-            18 1C   # unsigned(28) / suit-parameter-version: /
-            83      # array(3)
-               01   # unsigned(1)
-               00   # unsigned(0)
-               00   # unsigned(0)


### PR DESCRIPTION
QueryResponse example message contains suit-parameter-version defined in [SUIT Update Management document](https://datatracker.ietf.org/doc/html/draft-ietf-suit-update-management-02).
I've tried to include its CDDL, but there are several undefined elements, e.g. suit-directive-override-multiple, concise-software-identity, and it may require time to fix it.
Instead, I propose removing a system-property-claims to avoid this validation error.