### PR TITLE
Fix warning idnits tools after TEEP Architecture became RFC

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -96,7 +96,7 @@ informative:
   I-D.ietf-suit-firmware-encryption: 
   I-D.ietf-rats-ar4si:
   I-D.ietf-rats-reference-interaction-models:
-  I-D.ietf-teep-architecture: 
+  RFC9397:
   I-D.ietf-rats-eat-media-type:
   I-D.ietf-rats-concise-ta-stores:
   RFC8610: 


### PR DESCRIPTION
This PR fixes only one warning.
  == Outdated reference: draft-ietf-teep-architecture has been published as
     RFC 9397

Others warnings are from the text appended after submitting the ID and
not able to fix on the original md file.

The entire log of idnits.
```
  Miscellaneous warnings:
  ----------------------------------------------------------------------------

  -- The document date (3 July 2023) is 21 days in the past.  Is this
     intentional?

  -- Found something which looks like a code comment -- if you have code
     sections in the document, please surround them with '<CODE BEGINS>' and
     '<CODE ENDS>' lines.


  Checking references for intended status: Proposed Standard
  ----------------------------------------------------------------------------

     (See RFCs 3967 and 4897 for information about using normative references
     to lower-maturity documents in RFCs)

  == Outdated reference: A later version (-01) exists of
     draft-ietf-suit-mti-00

  == Outdated reference: A later version (-06) exists of
     draft-ietf-suit-report-05

  == Outdated reference: A later version (-04) exists of
     draft-ietf-suit-trust-domains-03

  == Outdated reference: A later version (-04) exists of
     draft-ietf-rats-eat-media-type-02

  == Outdated reference: A later version (-13) exists of
     draft-ietf-suit-firmware-encryption-12

  == Outdated reference: draft-ietf-teep-architecture has been published as
     RFC 9397
```