### PR TITLE
Respond to change RFC xml file

### DIFF
--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -54,7 +54,7 @@ $(COSE_XML):
 	curl https://www.rfc-editor.org/rfc/rfc9052.xml -o $@
 
 $(COSE_CDDL): $(COSE_XML)
-	sed -n -e '/<artwork type="CDDL"/,/<\/artwork/ p' $< | sed -e '/<artwork type="CDDL"/ d' -e '/<\/artwork/ d' -e '/<\/section>/,/<figure title=""/ d' -e 's/\&gt;/>/g' > $@
+	sed -n -e '/<sourcecode type="cddl"/,/<\/sourcecode>/ p' $< | sed -e '/<sourcecode type="cddl"/ d' -e '/<\/sourcecode>/ d' -e 's/\&gt;/>/g' > $@
 
 .PHONY: validate-cddl
 validate-cddl: validate-suit-cddl $(CONCATENATED_CDDL) $(TEEP_MESSAGES)


### PR DESCRIPTION
The xml tag wrapping CDDL has changed.
If you have local file of `rfc-9052-cose.xml` or `rfc-9052-cose.cddl`, please update them with `make -C cddl rfc-9052-cose.cddl -B`.