### PR TITLE
Fix suit-cose-profiles in examples

### DIFF
--- a/cbor/query_request.diag.txt
+++ b/cbor/query_request.diag.txt
@@ -6,11 +6,15 @@
     / token / 20 : h'A0A1A2A3A4A5A6A7A8A9AAABACADAEAF',
     / versions / 3 : [ 0 ]  / 0 is current TEEP Protocol /
   },
-  / supported-teep-cipher-suites: / [ [ [ 18, -7 ] ] / Sign1 using ES256 /,
-                                      [ [ 18, -8 ] ] / Sign1 using EdDSA /
-                                    ],
-  / supported-suit-cose-profiles: / [ [ -7, 1 ] / ES256+ECDH+A128GCM /,
-                                      [ -8, 1 ] / EdDSA+ECDH+A128GCM /
-                                    ],
+  / supported-teep-cipher-suites: / [
+    [ [ 18, -7 ] ] / Sign1 using ES256 /,
+    [ [ 18, -8 ] ] / Sign1 using EdDSA /
+  ],
+  / supported-suit-cose-profiles: / [
+    [-16, -7, -25, -65534] / suit-sha256-es256-ecdh-a128ctr /,
+    [-16, -8, -25, -65534] / suit-sha256-eddsa-ecdh-a128ctr /,
+    [-16, -7, -25, 1] / suit-sha256-es256-ecdh-a128gcm /,
+    [-16, -8, -25, 24] / suit-sha256-eddsa-ecdh-chacha-poly /
+  ],
   / data-item-requested: / 3 / attestation | trusted-components /
 ]

--- a/cbor/query_request.hex.txt
+++ b/cbor/query_request.hex.txt
@@ -16,11 +16,25 @@
          82         # array(2)
             12      # unsigned(18) / cose-sign1 /
             27      # negative(7) / -8 = cose-alg-eddsa /
-   82               # array(2) / supported-suit-cose-profiles /
-      82            # array(2) / suit-sha256-es256-ecdh-a128gcm /
-         26         # negative(6) / -7 = cose-alg-es256 /
-         01         # unsigned(1) / 1 = A128GCM /
-      82            # array(2) / suit-sha256-eddsa-ecdh-a128gcm /
-         27         # negative(7) / -8 = cose-alg-eddsa /
-         01         # unsigned(1) / 1 = A128GCM /
+   84               # array(4) / supported-suit-cose-profiles /
+      84            # array(4) / suit-sha256-es256-ecdh-a128ctr /,
+         2f         # negative(15) / -16 = SHA-256 /
+         26         # negative(6) / -7 = ES256 /
+         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         39 fffd    # negative(65533) / -65534 = A128CTR /
+      84            # array(4) / suit-sha256-eddsa-ecdh-a128ctr /
+         2f         # negative(15) / -16 = SHA-256 /
+         27         # negative(7) / -8 = EdDSA /
+         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         39 fffd    # negative(65533) / -65534 = A128CTR /
+      84            # array(4) / suit-sha256-es256-ecdh-a128gcm /
+         2f         # negative(15) / -16 = SHA-256 /
+         26         # negative(6) / -7 = ES256 /
+         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         01         # unsigned(1) / A128GCM /
+      84            # array(4) / suit-sha256-eddsa-ecdh-chacha-poly /
+         2f         # negative(15) / -16 = SHA-256 /
+         27         # negative(7) / EdDSA /
+         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         18 18      # unsigned(24) / 24 = ChaCha20/Poly1305 /
    03               # unsigned(3) / attestation | trusted-components /

--- a/cbor/query_response.diag.txt
+++ b/cbor/query_response.diag.txt
@@ -12,7 +12,7 @@
         / system-component-id / 0 : [ h'0102030405060708090A0B0C0D0E0F' ],
         / suit-parameter-image-digest / 3: << [
           / suit-digest-algorithm-id / -16 / SHA256 /,
-          / suit-digest-bytes / h'a7fd6593eac32eb4be578278e6540c5c09cfd7d4d234973054833b2b93030609'
+          / suit-digest-bytes / h'A7FD6593EAC32EB4BE578278E6540C5C09CFD7D4D234973054833B2B93030609'
             / SHA256 digest of tc binary /
         ] >>
       }

--- a/cbor/query_response.hex.txt
+++ b/cbor/query_response.hex.txt
@@ -8,7 +8,7 @@
       81            # array(1)
          82         # array(2)
             12      # unsigned(18) / cose-sign1 /
-            26      # negative(6) / -7 = cose-alg-es256 /
+            26      # negative(6) / -7 = ES256 /
       06            # unsigned(6) / selected-version: /
       00            # unsigned(0)
       07            # unsigned(7) / attestation-payload: /

--- a/cddl/Makefile
+++ b/cddl/Makefile
@@ -56,16 +56,22 @@ $(COSE_XML):
 $(COSE_CDDL): $(COSE_XML)
 	sed -n -e '/<sourcecode type="cddl"/,/<\/sourcecode>/ p' $< | sed -e '/<sourcecode type="cddl"/ d' -e '/<\/sourcecode>/ d' -e 's/\&gt;/>/g' > $@
 
+define FuncValidateCddl
+	cddl $1 validate $2
+
+endef
+
+
 .PHONY: validate-cddl
 validate-cddl: validate-suit-cddl $(CONCATENATED_CDDL) $(TEEP_MESSAGES)
 	@echo "Checking each TEEP Protocol binary file matches TEEP Protcol CDDL"
-	$(foreach msg,$(TEEP_MESSAGES),cddl $(CONCATENATED_CDDL) validate $(msg) || exit 1;)
+	$(foreach msg,$(TEEP_MESSAGES),$(call FuncValidateCddl,$(CONCATENATED_CDDL),$(msg)))
 	@echo "Success: Each TEEP Protocol message matches the CDDL"
 
 .PHONY: validate-suit-cddl
 validate-suit-cddl: $(CONCATENATED_UNTAGGED_SUIT_CDDL) $(SUIT_MANIFESTS)
 	@echo "Checking each SUIT Manifest binary file matches SUIT Manifest CDDL"
-	$(foreach mfst,$(SUIT_MANIFESTS),cddl $(CONCATENATED_UNTAGGED_SUIT_CDDL) validate $(mfst) || exit 1;)
+	$(foreach mfst,$(SUIT_MANIFESTS),$(call FuncValidateCddl,$(CONCATENATED_UNTAGGED_SUIT_CDDL),$(mfst)))
 	@echo "Success: Each SUIT Manifest matches the CDDL"
 
 .PHONY: validate-teep-cddl


### PR DESCRIPTION
@mcd500 
I've updated the QueryRequest example to list up suit-cose-profiles
- suit-sha256-es256-ecdh-a128ctr
- suit-sha256-eddsa-ecdh-a128ctr
- suit-sha256-es256-ecdh-a128gcm
- suit-sha256-eddsa-ecdh-chacha-poly