### PR TITLE
Reflect update on suit-sha256-es256-ecdh-a128ctr

### DIFF
--- a/cbor/query_request.diag.txt
+++ b/cbor/query_request.diag.txt
@@ -11,10 +11,10 @@
     [ [ 18, -8 ] ] / Sign1 using EdDSA /
   ],
   / supported-suit-cose-profiles: / [
-    [-16, -7, -25, -65534] / suit-sha256-es256-ecdh-a128ctr /,
-    [-16, -8, -25, -65534] / suit-sha256-eddsa-ecdh-a128ctr /,
-    [-16, -7, -25, 1] / suit-sha256-es256-ecdh-a128gcm /,
-    [-16, -8, -25, 24] / suit-sha256-eddsa-ecdh-chacha-poly /
+    [-16, -7, -29, -65534] / suit-sha256-es256-ecdh-a128ctr /,
+    [-16, -8, -29, -65534] / suit-sha256-eddsa-ecdh-a128ctr /,
+    [-16, -7, -29, 1]      / suit-sha256-es256-ecdh-a128gcm /,
+    [-16, -8, -29, 24]     / suit-sha256-eddsa-ecdh-chacha-poly /
   ],
   / data-item-requested: / 3 / attestation | trusted-components /
 ]

--- a/cbor/query_request.hex.txt
+++ b/cbor/query_request.hex.txt
@@ -20,21 +20,21 @@
       84            # array(4) / suit-sha256-es256-ecdh-a128ctr /,
          2f         # negative(15) / -16 = SHA-256 /
          26         # negative(6) / -7 = ES256 /
-         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         38 1C      # negative(28) / -29 = ECDH-ES + A128KW /
          39 fffd    # negative(65533) / -65534 = A128CTR /
       84            # array(4) / suit-sha256-eddsa-ecdh-a128ctr /
          2f         # negative(15) / -16 = SHA-256 /
          27         # negative(7) / -8 = EdDSA /
-         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         38 1C      # negative(28) / -29 = ECDH-ES + A128KW /
          39 fffd    # negative(65533) / -65534 = A128CTR /
       84            # array(4) / suit-sha256-es256-ecdh-a128gcm /
          2f         # negative(15) / -16 = SHA-256 /
          26         # negative(6) / -7 = ES256 /
-         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         38 1C      # negative(28) / -29 = ECDH-ES + A128KW /
          01         # unsigned(1) / A128GCM /
       84            # array(4) / suit-sha256-eddsa-ecdh-chacha-poly /
          2f         # negative(15) / -16 = SHA-256 /
          27         # negative(7) / EdDSA /
-         38 18      # negative(24) / -25 = ECDH-ES + HKDF-256 /
+         38 1C      # negative(28) / -29 = ECDH-ES + A128KW /
          18 18      # unsigned(24) / 24 = ChaCha20/Poly1305 /
    03               # unsigned(3) / attestation | trusted-components /

--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -17,7 +17,7 @@ abbrev: TEEP Protocol
 area: Security
 wg: TEEP
 kw: Trusted Execution Environment
-date: 2023
+date: 2024
 author:
 
  -


### PR DESCRIPTION
The SUIT Profile suit-sha256-es256-ecdh-a128ctr has been updated from ECDH-ES+HKDF-256 (-25) to ECDH-ES+A128KW (-29).

This PR must be merged after the CDDL of [suit-mti](https://github.com/bremoran/suit-mti/blob/main/draft-ietf-suit-mti.cddl#L17-L20) is updated.
I'll quickly create an Issue and a PR to it.
After that, validate example binaries with `make validate -B` .