### PR TITLE
Fix cddl syntax on $teep-type

### DIFF
--- a/draft-ietf-teep-protocol.md
+++ b/draft-ietf-teep-protocol.md
@@ -249,7 +249,7 @@ $teep-message-type /= teep-success
 $teep-message-type /= teep-error
 
 ; message type numbers, in one byte which could take a number from 0 to 23
-$teep-type = (0..23)
+$teep-type /= (0..23)
 TEEP-TYPE-query-request = 1
 TEEP-TYPE-query-response = 2
 TEEP-TYPE-update = 3


### PR DESCRIPTION
Syntax check message:
** warning: plain assignment of 0 .. 23 to type socket $teep-type